### PR TITLE
Jin fix imglayout

### DIFF
--- a/ftw/contentpage/browser/textblock_view.py
+++ b/ftw/contentpage/browser/textblock_view.py
@@ -18,7 +18,8 @@ class TextBlockView(BrowserView):
 
     def get_css_klass(self):
         layout = self.image_layout
-        return 'sl-img-' + layout
+        if layout:
+            return 'sl-img-' + layout
 
     def has_image(self):
         return bool(self.context.getImage())


### PR DESCRIPTION
@maethu fixes:
...
Module zope.tales.expressions, line 217, in **call**
  Module Products.PageTemplates.Expressions, line 155, in _eval
  Module Products.PageTemplates.Expressions, line 117, in render
  Module ftw.contentpage.browser.textblock_view, line 21, in get_css_klass
TypeError: cannot concatenate 'str' and 'NoneType' objects
