### PR TITLE
Do not let NewsFolder implement ISimpleLayoutCapable.

### DIFF
--- a/ftw/contentpage/content/newsfolder.py
+++ b/ftw/contentpage/content/newsfolder.py
@@ -1,7 +1,6 @@
 from Products.ATContentTypes.content import folder
 from AccessControl import ClassSecurityInfo
 from ftw.contentpage.config import PROJECTNAME
-from simplelayout.base.interfaces import ISimpleLayoutCapable
 from zope.interface import implements
 from ftw.contentpage.interfaces import INewsFolder
 from Products.ATContentTypes.config import HAS_LINGUA_PLONE
@@ -13,7 +12,7 @@ else:
 
 class NewsFolder(folder.ATFolder):
 
-    implements(INewsFolder, ISimpleLayoutCapable)
+    implements(INewsFolder)
     security = ClassSecurityInfo()
 
 


### PR DESCRIPTION
Do not let NewsFolder implement ISimpleLayoutCapable, so the news wont be published always, and the NewsFolder dont have the sl-design menu. @maethu 
