### PR TITLE
Rename categories field to content_categories

### DIFF
--- a/ftw/contentpage/configure.zcml
+++ b/ftw/contentpage/configure.zcml
@@ -32,7 +32,7 @@
         description="Create content the simplayout way"
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
-    
+
     <!-- Register the import step -->
     <genericsetup:importStep
         name="ftw.contentpage.custom"

--- a/ftw/contentpage/extender.py
+++ b/ftw/contentpage/extender.py
@@ -17,7 +17,7 @@ class CategoriesExtender(object):
     implements(IOrderableSchemaExtender)
 
     fields = [CategoriesField(
-        'categories',
+        'content_categories',
         multiValued=True,
         searchable=False,
         accessor='getContentCategories',

--- a/ftw/contentpage/indexer.py
+++ b/ftw/contentpage/indexer.py
@@ -4,4 +4,4 @@ from ftw.contentpage.interfaces import IContentPage
 
 @indexer(IContentPage)
 def categories(obj, **kw):
-    return obj.Schema()['categories'].get(obj)
+    return obj.Schema()['content_categories'].get(obj)

--- a/ftw/contentpage/tests/test_contentlisting.py
+++ b/ftw/contentpage/tests/test_contentlisting.py
@@ -52,10 +52,12 @@ class TestContentListing(TestCase):
         self.assertTrue(len(self._get_viewlet()) == 1)
 
     def test_category_field(self):
-        self.assertIn('categories', self.contentpage.Schema())
-        self.contentpage.Schema()['categories'].set(self.contentpage, 'DEMO1')
+        self.assertIn('content_categories', self.contentpage.Schema())
+        self.contentpage.Schema()['content_categories'].set(
+            self.contentpage, 'DEMO1')
         self.assertEquals(
-            self.contentpage.Schema()['categories'].get(self.contentpage),
+            self.contentpage.Schema()['content_categories'].get(
+                self.contentpage),
             ('DEMO1',))
 
     def test_category_index(self):
@@ -67,9 +69,9 @@ class TestContentListing(TestCase):
             self.contentpage.invokeFactory('ContentPage', 'subpage'))
         subpage.processForm()
         subpage.setTitle('Subpage title')
-        subpage.Schema()['categories'].set(subpage, 'DEMO1')
+        subpage.Schema()['content_categories'].set(subpage, 'DEMO1')
         subpage.reindexObject()
-        self.assertTrue(catalog({'categories': 'DEMO1'})[0])
+        self.assertTrue(catalog({'content_categories': 'DEMO1'})[0])
 
     def test_category_index_umlauts(self):
         catalog = getToolByName(self.portal, 'portal_catalog')
@@ -77,7 +79,8 @@ class TestContentListing(TestCase):
             self.contentpage.invokeFactory('ContentPage', 'subpage'))
         subpage.processForm()
         subpage.setTitle('Subpage title')
-        subpage.Schema()['categories'].set(subpage, 'WITH UTF8 \xc3\xa4')
+        subpage.Schema()['content_categories'].set(
+            subpage, 'WITH UTF8 \xc3\xa4')
         subpage.reindexObject()
         unique_values = catalog.Indexes['getContentCategories'].uniqueValues()
         self.assertIn("WITH UTF8 \xc3\xa4", unique_values)
@@ -88,31 +91,34 @@ class TestContentListing(TestCase):
         self.assertFalse(viewlet.available())
         # Create more content
         subpage = self.contentpage.get(
-            self.contentpage.invokeFactory('ContentPage', 'subpage', description='SubpageDescription'))
+            self.contentpage.invokeFactory(
+                'ContentPage', 'subpage', description='SubpageDescription'))
         subpage.setTitle('Subpage')
         # Test with umlauts
-        subpage.Schema()['categories'].set(subpage, '\xc3\xa4u\xc3\xa4')
+        subpage.Schema()['content_categories'].set(
+            subpage, '\xc3\xa4u\xc3\xa4')
         subpage.reindexObject()
         subpage2 = self.contentpage.get(
             self.contentpage.invokeFactory('ContentPage', 'subpage2'))
         subpage2.setTitle('Subpage2')
-        subpage2.Schema()['categories'].set(subpage2, 'DEMO2')
+        subpage2.Schema()['content_categories'].set(subpage2, 'DEMO2')
         subpage2.reindexObject()
         subpage3 = self.contentpage.get(
-            self.contentpage.invokeFactory('ContentPage', 'subpage3', description='OtherDescription'))
+            self.contentpage.invokeFactory(
+                'ContentPage', 'subpage3', description='OtherDescription'))
         subpage3.setTitle('Subpage3')
-        subpage3.Schema()['categories'].set(subpage3, 'DEMO2')
+        subpage3.Schema()['content_categories'].set(subpage3, 'DEMO2')
         subpage3.reindexObject()
 
         viewlet = self._get_viewlet()[0]
         self.assertTrue(viewlet.available())
-        self.assertEquals(viewlet.get_content(),
-                          [('\xc3\xa4u\xc3\xa4', [('Subpage',
-                                       subpage.absolute_url(), 'SubpageDescription')]),
-                           ('DEMO2', [('Subpage2',
-                                       subpage2.absolute_url(), 'Subpage2'),
-                                      ('Subpage3',
-                                       subpage3.absolute_url(), 'OtherDescription')])])
+        self.assertEquals(
+            viewlet.get_content(),
+            [('\xc3\xa4u\xc3\xa4',
+                [('Subpage', subpage.absolute_url(), 'SubpageDescription')]),
+             ('DEMO2',
+                [('Subpage2', subpage2.absolute_url(), 'Subpage2'),
+                 ('Subpage3', subpage3.absolute_url(), 'OtherDescription')])])
         transaction.commit()
         self._auth()
         self.browser.open(self.contentpage.absolute_url())

--- a/ftw/contentpage/viewlets/contentlisting.py
+++ b/ftw/contentpage/viewlets/contentlisting.py
@@ -23,7 +23,7 @@ class ContentListingViewlet(ViewletBase):
         if not contents:
             return []
         for obj in contents:
-            categories = obj.Schema()['categories'].get(obj)
+            categories = obj.Schema()['content_categories'].get(obj)
 
             for cat in categories:
                 if cat not in resultmap:


### PR DESCRIPTION
Plone and also a lot of other Packages are using `categories` in other circumstances. ex. Attributes. 
`content_categories` is more unique and should solve conflicts with other packages. 
