### PR TITLE
Remove blank target from image link in textblock.

### DIFF
--- a/ftw/contentpage/browser/textblock_view.pt
+++ b/ftw/contentpage/browser/textblock_view.pt
@@ -10,8 +10,7 @@
         <div class="sl-img-wrapper" tal:condition="view/has_image"
              tal:attributes="style view/image_wrapper_style"
              tal:define="image_desc context/getImageCaption | context/Description">
-                    <a  target="_blank"
-                        tal:attributes="
+                    <a  tal:attributes="
                                         title image_desc;
                                         href string:${context/absolute_url}/image
                                         "


### PR DESCRIPTION
This eliminates the "external link" problem in firefox if the theme looks on the targets.
See screenshot:
![externer_Link_weg_bei_Bilder_in_Block](https://f.cloud.github.com/assets/3796673/231686/745f46a2-870f-11e2-84d4-fca0dc8d9d79.PNG)

\cc @maethu 
