### PR TITLE
Add clearfix class to gallery

### DIFF
--- a/ftw/contentpage/browser/listingblock_gallery_view.pt
+++ b/ftw/contentpage/browser/listingblock_gallery_view.pt
@@ -3,7 +3,7 @@
     <h2 tal:content="here/Title" tal:condition="here/getShowTitle|python:True">Title</h2>
 
     <div class="sl-text-wrapper">
-      <div class="gallery">
+      <div class="gallery clearfix">
         <div class="box" tal:repeat="img python:view.get_images()">
             <div class="frame sl-img-wrapper" tal:define="width python:str(view._get_box_boundaries()[0])+'px';
                                            height python:str(view._get_box_boundaries()[1])+'px'"


### PR DESCRIPTION
... so the gallery will be cleared after the floated boxes.

before:
![before](https://f.cloud.github.com/assets/157533/269736/249ee57a-8faa-11e2-8175-6a2d1a9d9ace.png)

after:
![after](https://f.cloud.github.com/assets/157533/269737/24b6fa48-8faa-11e2-941b-400297af1c42.png)
