### PR TITLE
Fixed visualClear / added clearfix

### DIFF
--- a/ftw/contentpage/browser/addressblock_detail_view.pt
+++ b/ftw/contentpage/browser/addressblock_detail_view.pt
@@ -33,7 +33,7 @@
             <div tal:replace="structure view/address">Address</div>
           </div>
         </div>
-        <span class="visualClear">&nbsp;</span>
+        <div class="visualClear"><!-- --></div>
         
         <div tal:replace="structure provider:plone.belowcontentbody" />
 

--- a/ftw/contentpage/browser/addressblock_portlet_view.pt
+++ b/ftw/contentpage/browser/addressblock_portlet_view.pt
@@ -33,4 +33,4 @@
     </div>
 
 </div>
-<span class="visualClear">&nbsp;</span>
+<div class="visualClear"><!-- --></div>

--- a/ftw/contentpage/browser/addressblock_view.pt
+++ b/ftw/contentpage/browser/addressblock_view.pt
@@ -15,4 +15,4 @@
     </div>
 
 </div>
-<span class="visualClear">&nbsp;</span>
+<div class="visualClear"><!-- --></div>

--- a/ftw/contentpage/browser/listingblock_gallery_view.pt
+++ b/ftw/contentpage/browser/listingblock_gallery_view.pt
@@ -19,4 +19,4 @@
     </div>
 
 </div>
-<span class="visualClear">&nbsp;</span>
+<div class="visualClear"><!-- --></div>

--- a/ftw/contentpage/browser/listingblock_view.pt
+++ b/ftw/contentpage/browser/listingblock_view.pt
@@ -7,4 +7,4 @@
     </div>
 
 </div>
-<span class="visualClear">&nbsp;</span>
+<div class="visualClear"><!-- --></div>

--- a/ftw/contentpage/browser/news_block_view.pt
+++ b/ftw/contentpage/browser/news_block_view.pt
@@ -19,4 +19,4 @@
   </div>
   <div tal:condition="text" class="sl-text-wrapper" tal:content="structure text"></div>
 </div>
-<span class="visualClear">&nbsp;</span>
+<div class="visualClear"><!-- --></div>

--- a/ftw/contentpage/browser/textblock_view.pt
+++ b/ftw/contentpage/browser/textblock_view.pt
@@ -23,4 +23,4 @@
     </div>
     <div tal:condition="text" class="sl-text-wrapper" tal:content="structure text"></div>
 </div>
-<span class="visualClear">&nbsp;</span>
+<div class="visualClear"><!-- --></div>

--- a/ftw/contentpage/viewlets/simplelayout_news_listing_viewlet.pt
+++ b/ftw/contentpage/viewlets/simplelayout_news_listing_viewlet.pt
@@ -8,5 +8,5 @@
                  tal:content="structure python:view.renderBlockProvider(result)" />
         </tal:repeat>
      </div>
-    <span class="visualClear">&nbsp;</span>
+    <div class="visualClear"><!-- --></div>
 </div>


### PR DESCRIPTION
@maethu 

Replaced
`<span class="visualClear">&nbsp;</span>`
with
`<div class="visualClear"><!-- --></div>`

Also added `clearfix` class in newsblock view:
before:
![Bildschirmfoto 2013-03-18 um 14 41 18](https://f.cloud.github.com/assets/157533/270742/5d8ba6b0-8fd3-11e2-90c7-e81f3569b723.png)

after:
![Bildschirmfoto 2013-03-18 um 14 54 59](https://f.cloud.github.com/assets/157533/270751/79be0dfa-8fd3-11e2-945e-4ce7ade29a41.png)
