### PR TITLE
Browserviews should not be public.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1 (unreleased)
 ----------------
 
+- Browserviews should not be public.
+  [Julian Infanger]
+
 - Fill content-core slot instead of main slot and
   show edit-bar.
   [mathias.leimgruber]

--- a/ftw/contentpage/browser/configure.zcml
+++ b/ftw/contentpage/browser/configure.zcml
@@ -74,21 +74,21 @@
         for="*"
         name="news_listing"
         class=".newslisting.NewsListing"
-        permission="zope.Public"
+        permission="zope2.View"
         />
 
     <browser:page
         for="*"
         name="event_listing"
         class=".eventlisting.EventListing"
-        permission="zope.Public"
+        permission="zope2.View"
         />
 
     <browser:page
         for="*"
         name="news_rss_listing"
         class=".newslisting.NewsListing"
-        permission="zope.Public"
+        permission="zope2.View"
         allowed_attributes="news_result get_news"
         />
 


### PR DESCRIPTION
Replaced `permission="zope.Public"` with `permission="zope2.View"`.
"Public" should be done by publishing a content using a workflow. 
