### PR TITLE
Eventpage: getDate function

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1 (unreleased)
 ----------------
 
+- Add custom date formatter for events.
+  [mathias.leimgruber]
+
 - Improve test coverage
   [mathias.leimgruber]
 

--- a/ftw/contentpage/browser/eventlisting.pt
+++ b/ftw/contentpage/browser/eventlisting.pt
@@ -32,7 +32,7 @@
         <th i18n:translate="">
           Date
         </th>
-        <td tal:content="python: view.getDate(brain)" />
+        <td tal:content="python: view.get_date(brain)" />
       </tr>
       <tr tal:condition="brain/location">
         <th i18n:translate="">

--- a/ftw/contentpage/browser/eventlisting.py
+++ b/ftw/contentpage/browser/eventlisting.py
@@ -1,6 +1,24 @@
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from DateTime import DateTime
 from ftw.contentpage.browser.baselisting import BaseListing
+from Products.ATContentTypes.utils import DT2dt
+
+
+def format_date(start, end, wholeday):
+    start = DT2dt(start)
+    start_date = start.date().strftime('%d.%m.%Y')
+    start_time = start.time().strftime('%H:%M')
+    end = DT2dt(end)
+    end_date = end.date().strftime('%d.%m.%Y')
+    end_time = end.time().strftime('%H:%M')
+    if wholeday:
+        if start_date == end_date:
+            return start_date
+        return '%s - %s' % (start_date, end_date)
+    if start_date == end_date:
+        return '%s %s - %s' % (start_date, start_time, end_time)
+    return '%s %s - %s %s' % (
+          start_date, start_time, end_date, end_time)
 
 
 class EventListing(BaseListing):
@@ -15,6 +33,6 @@ class EventListing(BaseListing):
                  }
         return self.search_results(query, 'start')
 
-    def getDate(self, brain):
+    def get_date(self, brain):
         obj = brain.getObject()
-        return obj.getDate()
+        return format_date(obj.start(), obj.end(), obj.getWholeDay())

--- a/ftw/contentpage/content/eventpage.py
+++ b/ftw/contentpage/content/eventpage.py
@@ -9,7 +9,6 @@ from ftw.contentpage.interfaces import IEventPage
 from Products.Archetypes import atapi
 from Products.ATContentTypes.config import HAS_LINGUA_PLONE
 from Products.ATContentTypes.content.schemata import finalizeATCTSchema
-from Products.ATContentTypes.utils import DT2dt
 from zope.interface import implements
 
 
@@ -81,23 +80,6 @@ class EventPage(ContentPage):
     meta_type = "EventPage"
     schema = EventSchema
     security = ClassSecurityInfo()
-
-    def getDate(self):
-        start = DT2dt(self.start())
-        start_date = start.date().strftime('%d.%m.%Y')
-        if not self.getWholeDay():
-            start_time = start.time().strftime('%H:%M')
-            end = DT2dt(self.end())
-            end_date = end.date().strftime('%d.%m.%Y')
-            end_time = end.time().strftime('%H:%M')
-            # XXX not readable us %(dict)s
-            if start_date == end_date:
-                return start_date + ' ' + start_time + ' - ' + end_time
-            else:
-                return start_date + ' ' + start_time + ' -\
- ' + end_date + ' ' + end_time
-        else:
-            return start_date
 
     security.declarePublic('show_description')
     def show_description(self):

--- a/ftw/contentpage/tests/test_event_creation.py
+++ b/ftw/contentpage/tests/test_event_creation.py
@@ -1,8 +1,9 @@
-import unittest2 as unittest
+from ftw.contentpage.browser.eventlisting import format_date
 from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
-import transaction
-from plone.testing.z2 import Browser
 from plone.app.testing import TEST_USER_NAME, TEST_USER_PASSWORD
+from plone.testing.z2 import Browser
+import transaction
+import unittest2 as unittest
 
 
 class TestEvent(unittest.TestCase):
@@ -40,4 +41,6 @@ class TestEvent(unittest.TestCase):
             'http://nohost/plone/eventfolder/a-title/')
         event = self.eventfolder.get('a-title')
         self.assertEqual(event.location.encode('utf-8'), 'D\xc3\xbcbendorf')
-        self.assertEqual(event.getDate(), '20.05.2013 07:20 - 08:20')
+        self.assertEqual(
+            format_date(event.start(), event.end(), event.getWholeDay()),
+            '20.05.2013 07:20 - 08:20')

--- a/ftw/contentpage/tests/test_event_date.py
+++ b/ftw/contentpage/tests/test_event_date.py
@@ -1,39 +1,38 @@
 from DateTime import DateTime
-from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
-from plone.testing.z2 import Browser
-import transaction
+from ftw.contentpage.browser.eventlisting import format_date
 import unittest2 as unittest
 
 
 class TestEvent(unittest.TestCase):
 
-    layer = FTW_CONTENTPAGE_FUNCTIONAL_TESTING
+    def test_same_date(self):
+        start = DateTime(2013, 01, 01, 18, 00)
+        end = DateTime(2013, 01, 01, 19, 00)
+        wholeday = False
 
-    def setUp(self):
-        self.portal = self.layer['portal']
-        self.eventfolder = self.portal.get(
-            self.portal.invokeFactory('EventFolder', 'eventfolder'))
-        self.event = self.eventfolder.get(
-            self.eventfolder.invokeFactory('EventPage', 'event'))
-        transaction.commit()
-        self.browser = Browser(self.layer['app'])
-        self.browser.handleErrors = False
+        self.assertEquals(format_date(start, end, wholeday),
+            '01.01.2013 18:00 - 19:00')
 
-    def test_event_date_single_day(self):
-        self.event.startDate = DateTime(2013, 05, 30, 18, 00)
-        self.event.endDate = DateTime(2013, 05, 30, 19, 00)
-        date = self.event.getDate()
-        self.assertEqual(date, '30.05.2013 18:00 - 19:00')
+    def test_diff_date(self):
+        start = DateTime(2013, 01, 01, 18, 00)
+        end = DateTime(2013, 01, 03, 19, 00)
+        wholeday = False
 
-    def test_event_date_multiple_day(self):
-        self.event.startDate = DateTime(2013, 05, 30, 18, 00)
-        self.event.endDate = DateTime(2013, 05, 31, 19, 00)
-        date = self.event.getDate()
-        self.assertEqual(date, '30.05.2013 18:00 - 31.05.2013 19:00')
+        self.assertEquals(format_date(start, end, wholeday),
+            '01.01.2013 18:00 - 03.01.2013 19:00')
 
-    def test_event_date_whole_day(self):
-        self.event.startDate = DateTime(2013, 05, 30, 18, 00)
-        self.event.endDate = DateTime(2013, 05, 30, 19, 00)
-        self.event.wholeDay = True
-        date = self.event.getDate()
-        self.assertEqual(date, '30.05.2013')
+    def test_same_date_wholeday(self):
+        start = DateTime(2013, 01, 01)
+        end = DateTime(2013, 01, 01)
+        wholeday = True
+
+        self.assertEquals(format_date(start, end, wholeday),
+            '01.01.2013')
+
+    def test_diff_date_wholeday(self):
+        start = DateTime(2013, 01, 01)
+        end = DateTime(2013, 01, 03)
+        wholeday = True
+
+        self.assertEquals(format_date(start, end, wholeday),
+            '01.01.2013 - 03.01.2013')

--- a/ftw/contentpage/viewlets/event_data.pt
+++ b/ftw/contentpage/viewlets/event_data.pt
@@ -4,7 +4,7 @@
         <th i18n:translate="">
           Date
         </th>
-        <td tal:content="context/getDate" />
+        <td tal:content="view/get_date" />
       </tr>
       <tr tal:condition="context/location">
         <th i18n:translate="">

--- a/ftw/contentpage/viewlets/event_data.py
+++ b/ftw/contentpage/viewlets/event_data.py
@@ -1,3 +1,4 @@
+from ftw.contentpage.browser.eventlisting import format_date
 from plone.app.layout.viewlets import ViewletBase
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
@@ -5,3 +6,7 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 class EventDataViewlet(ViewletBase):
 
     index = ViewPageTemplateFile("event_data.pt")
+
+    def get_date(self):
+        return format_date(self.context.start(), self.context.end(),
+                           self.context.getWholeDay())


### PR DESCRIPTION
https://github.com/4teamwork/ftw.contentpage/blob/master/ftw/contentpage/content/eventpage.py#L85
Function `getDate` has a strange behavior:
- Whole day events only displays the start date
- Unused time is shown

Do something like:

``` python
def getDate(self):
      start = DT2dt(self.start())
      start_date = start.date().strftime('%d.%m.%Y')
      start_time = start.time().strftime('%H:%M')
      end = DT2dt(self.end())
      end_date = end.date().strftime('%d.%m.%Y')
      end_time = end.time().strftime('%H:%M')

      if self.getWholeDay():
          if start_date == end_date:
              return start_date
          return '%s - %s' % (start_date, end_date)

      if start_date == end_date:
          return '%s %s - %s ' % (start_date, start_time, end_time)
      return '%s %s - %s %s ' % (
          start_date, start_time, end_date, end_time)
```

or

``` python
def pretty_date(self, brain):
    context = aq_inner(self.context)
    ttool = getToolByName(context, 'translation_service')

    start = brain.start
    end = brain.end

    startYear = start.year()
    endYear = end.year()
    startMonth = ttool.utranslate(domain='plonelocales', msgid=ttool.month_msgid(start.month()),context=context)
    endMonth = ttool.utranslate(domain='plonelocales', msgid=ttool.month_msgid(end.month()),context=context)
    startDay = start.day()
    endDay = end.day()

    datestr = ''
    # multi day event
    if startYear != endYear or startMonth != endMonth or startDay != endDay:
        # multi year
        if startYear != endYear:
            datestr = _(u'pretty_date_multi_year',
                        default=u'${sday}. ${smonth} ${syear} - ${eday}. ${emonth} ${eyear}',
                        mapping={'sday':startDay,'smonth':startMonth, 'syear':startYear,
                                 'eday':endDay, 'emonth':endMonth, 'eyear':endYear})
        # multi Month
        elif startMonth != endMonth:
            datestr = _(u'pretty_date_multi_month',
                        default=u'${sday}. ${smonth} - ${eday}. ${emonth} ${eyear}',
                        mapping={'sday':startDay,'smonth':startMonth,
                                 'eday':endDay, 'emonth':endMonth, 'eyear':endYear})
        # multi day
        else:
            datestr = _(u'pretty_date_multi_day',
                        default=u'${sday}. - ${eday}. ${emonth} ${eyear}',
                        mapping={'sday':startDay,'eday':endDay,
                                 'emonth':endMonth, 'eyear':endYear})
    # same day
    else:
        datestr = _(u'pretty_date_same_day',
                    default=u'${day}. ${month} ${year}',
                    mapping={'day':startDay,'month':startMonth,'year': startYear},)

    return datestr
```
