### PR TITLE
Fix off-by-one error in listingblock.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 1.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix off-by-one error in listingblock.
+  This caused that the listingblock was not displayed when only one item
+  was in the listingblock and the block was not editable.
+  [jone]
 
 
 1.2 (2013-05-27)

--- a/ftw/contentpage/browser/listingblock_view.py
+++ b/ftw/contentpage/browser/listingblock_view.py
@@ -60,7 +60,7 @@ class ListingBlockView(BrowserView):
         if mtool.checkPermission('Modify portal content', self.context):
             return True
 
-        return len(self.get_table_contents()) > 1
+        return len(self.get_table_contents()) > 0
 
     @property
     def _build_query(self):


### PR DESCRIPTION
This caused that the listingblock was not displayed when only one item
was in the listingblock and the block was not editable.

/cc @maethu 
