### PR TITLE
Addressblock displays the contentpages title

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Suggest the parents title for addresstitle in addressblock.
+  Its the better way than just display it if no addresstitle is set.
+  [Julian Infanger]
 
 
 1.2.1 (2013-06-03)

--- a/ftw/contentpage/browser/address.pt
+++ b/ftw/contentpage/browser/address.pt
@@ -1,6 +1,8 @@
 <tal:block  i18n:domain="ftw.contentpage">
   <p>
-    <span tal:replace="python: context.getAddressTitle() and context.getAddressTitle() or context.aq_parent.Title()" /><br />
+    <tal:addresstitle condition="context/getAddressTitle">
+      <span tal:replace="context/getAddressTitle" /><br />
+    </tal:addresstitle>
     <span tal:replace="structure view/get_address_as_html" /><br />
     <span tal:replace="context/getZip" />
     <span tal:replace="context/getCity" /><br />

--- a/ftw/contentpage/content/addressblock.py
+++ b/ftw/contentpage/content/addressblock.py
@@ -1,4 +1,6 @@
 from AccessControl import ClassSecurityInfo
+from Acquisition import aq_parent
+from borg.localrole.interfaces import IFactoryTempFolder
 from ftw.contentpage import _
 from ftw.contentpage import config
 from ftw.contentpage.content.schema import finalize
@@ -31,6 +33,7 @@ schema = atapi.Schema((
     atapi.StringField(
         name='addressTitle',
         schemata='default',
+        default_method='getDefaultAddressTitle',
         widget=atapi.StringWidget(
             label=_(u'label_addressTitle',
                     default=u'Address Title'))),
@@ -174,5 +177,12 @@ class AddressBlock(ATCTContent, HistoryAwareMixin):
             registry.get('ftw.contentpage.addressblock.defaulttitle', ''),
             domain='ftw.contentpage',
             context=self.REQUEST)
+
+    security.declarePrivate('getDefaultAddressTitle')
+    def getDefaultAddressTitle(self):
+        parent = aq_parent(self)
+        if IFactoryTempFolder.providedBy(parent):
+            parent = aq_parent(aq_parent(parent))
+        return parent.Title()
 
 atapi.registerType(AddressBlock, config.PROJECTNAME)


### PR DESCRIPTION
If there is no addresstitle, the parents contentpage title will be displayed:
https://github.com/4teamwork/ftw.contentpage/blob/master/ftw/contentpage/browser/address.pt#L3
But now there is no chance to don't set an addresstitle. It could be a better way to suggest the parents title in the add form as default value for the addresstitle?
