### PR TITLE
Register the `IOrgUnitMarker` interface so that it is avaiable in ZMI

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Register the `IOrgUnitMarker` interface so that it is avaiable in manage_interfaces.
+  [jone]
+
 - Suggest the parents title for addresstitle in addressblock.
   Its the better way than just display it if no addresstitle is set.
   [Julian Infanger]

--- a/ftw/contentpage/configure.zcml
+++ b/ftw/contentpage/configure.zcml
@@ -25,6 +25,9 @@
 
     <include zcml:condition="installed ftw.lawgiver" file="lawgiver.zcml" />
 
+    <!-- register interfaces so that they are available in manage_interfaces -->
+    <interface interface="ftw.contentpage.interfaces.IOrgUnitMarker" />
+
     <i18n:registerTranslations directory="locales" />
 
     <!-- Register the installation GenericSetup extension profile -->


### PR DESCRIPTION
-> show it on `manage_interfaces`
