### PR TITLE
Enable categorization for PFG forms.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 - Add department field to addressblock.
   [treinhard]
 
+- Enable categorization for PFG forms.
+  [treinhard]
 
 1.3 (2013-06-13)
 ----------------

--- a/ftw/contentpage/configure.zcml
+++ b/ftw/contentpage/configure.zcml
@@ -56,6 +56,13 @@
          provides="archetypes.schemaextender.interfaces.IOrderableSchemaExtender"
          name="ftw.contentpage.category.extender" />
 
+    <!-- Make PloneFormGen forms categorizable -->
+    <configure zcml:condition="installed Products.PloneFormGen">
+        <class class="Products.PloneFormGen.content.form.FormFolder">
+            <implements interface="ftw.contentpage.interfaces.ICategorizable" />
+        </class>
+    </configure>
+
     <!-- Register ftw.geo adapter -->
     <adapter factory=".geo.AddressBlockLocationAdapter" />
     <adapter


### PR DESCRIPTION
I'm a little bit confused because there are now two keyword fields: One in the "Standard" edit tab and the other in the "Kategorisierung" edit tab.
