### PR TITLE
Change queries for archive and news portlets from portal_type to provided interfaces

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.4 (unreleased)
 ----------------
 
+- Change queries for archive and news portlets from portal_type to provided
+  interfaces
+  [eschmutz]
+
 - Change inser-after to insert-after in viewlets.xml
   [elioschmutz]
 

--- a/ftw/contentpage/portlets/base_archive_portlet.py
+++ b/ftw/contentpage/portlets/base_archive_portlet.py
@@ -15,7 +15,7 @@ def zLocalizedTime(request, time, long_format=False):
     return u"%s %s" % (month, time.strftime('%Y'))
 
 
-def archive_summary(context, request, contenttype, datefield, viewname):
+def archive_summary(context, request, interfaces, datefield, viewname):
     """Returns an ordered list of summary infos per month."""
     catalog = getToolByName(context, 'portal_catalog')
     query = {}
@@ -29,7 +29,7 @@ def archive_summary(context, request, contenttype, datefield, viewname):
         root_path = '/'.join(context.getPhysicalPath())
 
     query['path'] = root_path
-    query['portal_type'] = contenttype
+    query['object_provides'] = interfaces
 
     archive_counts = {}
     entries = catalog(**query)

--- a/ftw/contentpage/portlets/event_archive.py
+++ b/ftw/contentpage/portlets/event_archive.py
@@ -45,7 +45,7 @@ class Renderer(base.Renderer):
     def archive_summary(self):
         return archive_summary(self.context,
                                self.request,
-                               'EventPage',
+                               ['ftw.contentpage.interfaces.IEventPage'],
                                'start',
                                'event_listing'
                                )

--- a/ftw/contentpage/portlets/news_archive_portlet.py
+++ b/ftw/contentpage/portlets/news_archive_portlet.py
@@ -43,8 +43,12 @@ class Renderer(base.Renderer):
     @memoize
     def archive_summary(self):
         """Returns an ordered list of summary infos per month."""
-        return archive_summary(self.context, self.request, 'News', 'effective',
-                               'news_listing')
+        return archive_summary(
+            self.context,
+            self.request,
+            ['ftw.contentpage.interfaces.INews'],
+            'effective',
+            'news_listing')
 
     render = ViewPageTemplateFile('news_archive_portlet.pt')
 

--- a/ftw/contentpage/portlets/news_portlet.py
+++ b/ftw/contentpage/portlets/news_portlet.py
@@ -218,7 +218,7 @@ class Renderer(base.Renderer):
         catalog = getToolByName(self.context, 'portal_catalog')
         url_tool = getToolByName(self.context, 'portal_url')
         portal_path = url_tool.getPortalPath()
-        query = {'portal_type': 'News'}
+        query = {'object_provides': 'ftw.contentpage.interfaces.INews'}
 
         if self.data.only_context:
             path = '/'.join(self.context.getPhysicalPath())


### PR DESCRIPTION
@maethu I expanded the interfaces query implementation to the archive, news an event portlet. Please take a look on it
