### PR TITLE
Added view for contentpage to display the blocks as tabs.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.4 (unreleased)
 ----------------
 
+- Added view for contentpage to display the blocks as tabs.
+  [Julian Infanger]
+
 - Updated translations for url field in addressblock.
   [Julian Infanger]
 

--- a/ftw/contentpage/browser/configure.zcml
+++ b/ftw/contentpage/browser/configure.zcml
@@ -47,6 +47,12 @@
         permission="zope2.View"
         template="authorities.pt" />
 
+     <browser:page
+         for="ftw.contentpage.interfaces.IContentPage"
+         name="tabbed_block_view"
+         class=".tabs.TabbedBlockView"
+         permission="zope2.View" />
+
     <!-- ListingBlock views -->
     <browser:page
         for="ftw.contentpage.interfaces.IListingBlock"

--- a/ftw/contentpage/browser/resources/contentpage.css
+++ b/ftw/contentpage/browser/resources/contentpage.css
@@ -66,3 +66,21 @@
   display: none;
 }
 /* @end */
+
+/* @group tabbed block view */
+
+body.template-tabbed_block_view #content ul.formTabs {
+  margin-bottom: 1em;
+}
+body.template-tabbed_block_view #content #content-core .document-action-dragme {
+  display: none !important;
+}
+body.template-tabbed_block_view #content .simplelayout-content.two-columns-design .twocolumn {
+  width: 100%;
+  float: none;
+}
+body.template-tabbed_block_view .slAlignBlocks {
+  display: none;
+}
+
+/* @end */

--- a/ftw/contentpage/browser/tabs.pt
+++ b/ftw/contentpage/browser/tabs.pt
@@ -1,0 +1,51 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="ftw.contentpage">
+
+  <body>
+
+    <metal:javascriptslot fill-slot="javascript_head_slot">
+      <script type="text/javascript">
+        jQuery(function($) {
+          $(".template-tabbed_block_view ul.formTabs").tabs(".BlockOverallWrapper", {
+            current: 'selected'
+          });
+        });
+      </script>
+    </metal:javascriptslot>
+
+    <div metal:fill-slot="content-description">
+      <metal:main-macro define-macro="content-description">
+        <!-- no description, its in a viewlet -->
+      </metal:main-macro>
+    </div>
+
+
+    <div metal:fill-slot="content-core">
+      <metal:main-macro define-macro="content-core"
+                        tal:define="children view/children">
+
+        <tal:children condition="children">
+          <ul class="formTabs">
+            <li class="formTab" tal:repeat="child children">
+              <a tal:attributes="href child/absolute_url"
+                 tal:content="child/title_or_id"
+                 />
+            </li>
+          </ul>
+          <tal:block content="structure provider:simplelayout.base.listing" />
+        </tal:children>
+
+        <tal:no_children condition="not:children">
+          <span i18n:translate="">There are no blocks in here.</span>
+        </tal:no_children>
+
+
+      </metal:main-macro>
+    </div>
+  </body>
+</html>

--- a/ftw/contentpage/browser/tabs.py
+++ b/ftw/contentpage/browser/tabs.py
@@ -1,0 +1,14 @@
+from zope.publisher.browser import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class TabbedBlockView(BrowserView):
+    template = ViewPageTemplateFile('tabs.pt')
+
+    def __call__(self):
+        return self.template()
+
+    def children(self):
+        return self.context.getFolderContents(
+            contentFilter={'object_provides': 'simplelayout.base.interfaces.IOneColumn'},
+            full_objects=True)

--- a/ftw/contentpage/locales/de/LC_MESSAGES/ftw.contentpage.po
+++ b/ftw/contentpage/locales/de/LC_MESSAGES/ftw.contentpage.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-06-07 09:42+0000\n"
+"POT-Creation-Date: 2013-07-02 13:42+0000\n"
 "PO-Revision-Date: 2013-04-11 18:16+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -120,6 +120,10 @@ msgstr "Schweiz"
 msgid "TextBlock"
 msgstr "Textblock"
 
+#: ./ftw/contentpage/browser/tabs.pt:44
+msgid "There are no blocks in here."
+msgstr "Hier sind noch keine Inhalte."
+
 #: ./ftw/contentpage/portlets/news_portlet.py:102
 msgid "This Portlet displays News"
 msgstr "Ein Portlet, um News darzustellen."
@@ -199,7 +203,7 @@ msgstr "Wird das Bild angeklickt, öffnet es sich in einem Overlay"
 msgid "help_categories"
 msgstr "Definieren Sie, unter welchen Rubrik diese Inhaltsseite abgelegt werden soll"
 
-#: ./ftw/contentpage/content/addressblock.py:140
+#: ./ftw/contentpage/content/addressblock.py:147
 msgid "help_directions"
 msgstr "So finden Sie uns"
 
@@ -212,7 +216,7 @@ msgstr "Datum und Zeit, wann diese Veranstaltung endet"
 msgid "help_event_location"
 msgstr ""
 
-#: ./ftw/contentpage/content/addressblock.py:92
+#: ./ftw/contentpage/content/addressblock.py:99
 msgid "help_fax"
 msgstr ""
 
@@ -220,15 +224,15 @@ msgstr ""
 msgid "help_only_context"
 msgstr "Wenn ausgewählt, werden nur noch News aus dem aktuellen Bereich dargestellt"
 
-#: ./ftw/contentpage/content/addressblock.py:129
+#: ./ftw/contentpage/content/addressblock.py:136
 msgid "help_openingHours"
 msgstr "Es gelten die folgenden Öffnungszeiten"
 
-#: ./ftw/contentpage/content/addressblock.py:83
+#: ./ftw/contentpage/content/addressblock.py:90
 msgid "help_phone"
 msgstr ""
 
-#: ./ftw/contentpage/content/addressblock.py:118
+#: ./ftw/contentpage/content/addressblock.py:125
 msgid "help_showOpeningHours"
 msgstr "Definieren Sie, ob die Hinweise zu den Öffnungszeiten angezeigt werden sollen"
 
@@ -266,7 +270,7 @@ msgid "label_%ssort_index"
 msgstr ""
 
 #. Default: "Address"
-#: ./ftw/contentpage/content/addressblock.py:45
+#: ./ftw/contentpage/content/addressblock.py:52
 msgid "label_address"
 msgstr "Adresse"
 
@@ -274,9 +278,6 @@ msgstr "Adresse"
 #: ./ftw/contentpage/content/addressblock.py:38
 msgid "label_addressTitle"
 msgstr "Adresstitel"
-
-msgid "label_department"
-msgstr "Abteilung"
 
 #. Default: "Ascending"
 #: ./ftw/contentpage/content/listingblock.py:55
@@ -299,12 +300,12 @@ msgid "label_categories"
 msgstr "Rubrik"
 
 #. Default: "City"
-#: ./ftw/contentpage/content/addressblock.py:66
+#: ./ftw/contentpage/content/addressblock.py:73
 msgid "label_city"
 msgstr "Ort"
 
 #. Default: "Country"
-#: ./ftw/contentpage/content/addressblock.py:74
+#: ./ftw/contentpage/content/addressblock.py:81
 msgid "label_country"
 msgstr "Land"
 
@@ -312,6 +313,11 @@ msgstr "Land"
 #: ./ftw/contentpage/portlets/news_portlet.py:79
 msgid "label_days"
 msgstr "Anzahl Tage"
+
+#. Default: "Department"
+#: ./ftw/contentpage/content/addressblock.py:45
+msgid "label_department"
+msgstr "Abteilung"
 
 #: ./ftw/contentpage/portlets/news_portlet.py:76
 msgid "label_desc_length"
@@ -323,13 +329,13 @@ msgid "label_descending"
 msgstr "Absteigend"
 
 #. Default: "Directions"
-#: ./ftw/contentpage/browser/address.pt:40
-#: ./ftw/contentpage/content/addressblock.py:138
+#: ./ftw/contentpage/browser/address.pt:43
+#: ./ftw/contentpage/content/addressblock.py:145
 msgid "label_directions"
 msgstr "Anfahrt"
 
 #. Default: "Email"
-#: ./ftw/contentpage/content/addressblock.py:99
+#: ./ftw/contentpage/content/addressblock.py:106
 msgid "label_email"
 msgstr "E-Mail"
 
@@ -349,12 +355,12 @@ msgid "label_event_start"
 msgstr "Veranstaltungsanfang"
 
 #. Default: "Extra address line"
-#: ./ftw/contentpage/content/addressblock.py:52
+#: ./ftw/contentpage/content/addressblock.py:59
 msgid "label_extraAddressLine"
 msgstr "Adresszusatz"
 
 #. Default: "Fax"
-#: ./ftw/contentpage/content/addressblock.py:90
+#: ./ftw/contentpage/content/addressblock.py:97
 msgid "label_fax"
 msgstr "Fax"
 
@@ -402,13 +408,13 @@ msgid "label_only_context"
 msgstr "Nur in diesem Bereich"
 
 #. Default: "Opening Hours"
-#: ./ftw/contentpage/browser/address.pt:35
-#: ./ftw/contentpage/content/addressblock.py:127
+#: ./ftw/contentpage/browser/address.pt:38
+#: ./ftw/contentpage/content/addressblock.py:134
 msgid "label_openingHours"
 msgstr "Öffnungszeiten"
 
 #. Default: "Phone"
-#: ./ftw/contentpage/content/addressblock.py:81
+#: ./ftw/contentpage/content/addressblock.py:88
 msgid "label_phone"
 msgstr "Telefon"
 
@@ -442,7 +448,7 @@ msgid "label_send_feedback"
 msgstr "Kontaktformular"
 
 #. Default: "Show opening hours"
-#: ./ftw/contentpage/content/addressblock.py:116
+#: ./ftw/contentpage/content/addressblock.py:123
 msgid "label_showOpeningHours"
 msgstr "Öffnungszeiten anzeigen"
 
@@ -500,12 +506,12 @@ msgid "label_whole_day_event"
 msgstr "Ganztägige Veranstaltung"
 
 #. Default: "WWW"
-#: ./ftw/contentpage/content/addressblock.py:107
+#: ./ftw/contentpage/content/addressblock.py:114
 msgid "label_www"
 msgstr "WWW"
 
 #. Default: "ZIP"
-#: ./ftw/contentpage/content/addressblock.py:59
+#: ./ftw/contentpage/content/addressblock.py:66
 msgid "label_zip"
 msgstr "PLZ"
 
@@ -530,7 +536,7 @@ msgid "review_state"
 msgstr "Status"
 
 #. Default: "Fax ${num}"
-#: ./ftw/contentpage/browser/address.pt:18
+#: ./ftw/contentpage/browser/address.pt:21
 msgid "text_fax"
 msgstr "Fax ${num}"
 
@@ -546,6 +552,6 @@ msgid "text_path_and_area"
 msgstr "Sie können keinen Pfad definieren und gleichzeitig den Bereich einschränken."
 
 #. Default: "Tel. ${num}"
-#: ./ftw/contentpage/browser/address.pt:11
+#: ./ftw/contentpage/browser/address.pt:14
 msgid "text_phone"
 msgstr "Tel. ${num}"

--- a/ftw/contentpage/locales/de/LC_MESSAGES/plone.po
+++ b/ftw/contentpage/locales/de/LC_MESSAGES/plone.po
@@ -17,3 +17,6 @@ msgstr "Organisationsübersicht"
 
 msgid "simplelayout_summary"
 msgstr "Simplelayout Zusammenfassung"
+
+msgid "tabbed_block_view"
+msgstr "Inhaltsseite mit Tabs"

--- a/ftw/contentpage/locales/ftw.contentpage.pot
+++ b/ftw/contentpage/locales/ftw.contentpage.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-06-07 09:42+0000\n"
+"POT-Creation-Date: 2013-07-02 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -122,6 +122,10 @@ msgstr ""
 msgid "TextBlock"
 msgstr ""
 
+#: ./ftw/contentpage/browser/tabs.pt:44
+msgid "There are no blocks in here."
+msgstr ""
+
 #: ./ftw/contentpage/portlets/news_portlet.py:102
 msgid "This Portlet displays News"
 msgstr ""
@@ -201,7 +205,7 @@ msgstr ""
 msgid "help_categories"
 msgstr ""
 
-#: ./ftw/contentpage/content/addressblock.py:140
+#: ./ftw/contentpage/content/addressblock.py:147
 msgid "help_directions"
 msgstr ""
 
@@ -214,7 +218,7 @@ msgstr ""
 msgid "help_event_location"
 msgstr ""
 
-#: ./ftw/contentpage/content/addressblock.py:92
+#: ./ftw/contentpage/content/addressblock.py:99
 msgid "help_fax"
 msgstr ""
 
@@ -222,15 +226,15 @@ msgstr ""
 msgid "help_only_context"
 msgstr ""
 
-#: ./ftw/contentpage/content/addressblock.py:129
+#: ./ftw/contentpage/content/addressblock.py:136
 msgid "help_openingHours"
 msgstr ""
 
-#: ./ftw/contentpage/content/addressblock.py:83
+#: ./ftw/contentpage/content/addressblock.py:90
 msgid "help_phone"
 msgstr ""
 
-#: ./ftw/contentpage/content/addressblock.py:118
+#: ./ftw/contentpage/content/addressblock.py:125
 msgid "help_showOpeningHours"
 msgstr ""
 
@@ -268,7 +272,7 @@ msgid "label_%ssort_index"
 msgstr ""
 
 #. Default: "Address"
-#: ./ftw/contentpage/content/addressblock.py:45
+#: ./ftw/contentpage/content/addressblock.py:52
 msgid "label_address"
 msgstr ""
 
@@ -298,18 +302,23 @@ msgid "label_categories"
 msgstr ""
 
 #. Default: "City"
-#: ./ftw/contentpage/content/addressblock.py:66
+#: ./ftw/contentpage/content/addressblock.py:73
 msgid "label_city"
 msgstr ""
 
 #. Default: "Country"
-#: ./ftw/contentpage/content/addressblock.py:74
+#: ./ftw/contentpage/content/addressblock.py:81
 msgid "label_country"
 msgstr ""
 
 #. Default: "Days"
 #: ./ftw/contentpage/portlets/news_portlet.py:79
 msgid "label_days"
+msgstr ""
+
+#. Default: "Department"
+#: ./ftw/contentpage/content/addressblock.py:45
+msgid "label_department"
 msgstr ""
 
 #: ./ftw/contentpage/portlets/news_portlet.py:76
@@ -322,13 +331,13 @@ msgid "label_descending"
 msgstr ""
 
 #. Default: "Directions"
-#: ./ftw/contentpage/browser/address.pt:40
-#: ./ftw/contentpage/content/addressblock.py:138
+#: ./ftw/contentpage/browser/address.pt:43
+#: ./ftw/contentpage/content/addressblock.py:145
 msgid "label_directions"
 msgstr ""
 
 #. Default: "Email"
-#: ./ftw/contentpage/content/addressblock.py:99
+#: ./ftw/contentpage/content/addressblock.py:106
 msgid "label_email"
 msgstr ""
 
@@ -348,12 +357,12 @@ msgid "label_event_start"
 msgstr ""
 
 #. Default: "Extra address line"
-#: ./ftw/contentpage/content/addressblock.py:52
+#: ./ftw/contentpage/content/addressblock.py:59
 msgid "label_extraAddressLine"
 msgstr ""
 
 #. Default: "Fax"
-#: ./ftw/contentpage/content/addressblock.py:90
+#: ./ftw/contentpage/content/addressblock.py:97
 msgid "label_fax"
 msgstr ""
 
@@ -401,13 +410,13 @@ msgid "label_only_context"
 msgstr ""
 
 #. Default: "Opening Hours"
-#: ./ftw/contentpage/browser/address.pt:35
-#: ./ftw/contentpage/content/addressblock.py:127
+#: ./ftw/contentpage/browser/address.pt:38
+#: ./ftw/contentpage/content/addressblock.py:134
 msgid "label_openingHours"
 msgstr ""
 
 #. Default: "Phone"
-#: ./ftw/contentpage/content/addressblock.py:81
+#: ./ftw/contentpage/content/addressblock.py:88
 msgid "label_phone"
 msgstr ""
 
@@ -441,7 +450,7 @@ msgid "label_send_feedback"
 msgstr ""
 
 #. Default: "Show opening hours"
-#: ./ftw/contentpage/content/addressblock.py:116
+#: ./ftw/contentpage/content/addressblock.py:123
 msgid "label_showOpeningHours"
 msgstr ""
 
@@ -499,12 +508,12 @@ msgid "label_whole_day_event"
 msgstr ""
 
 #. Default: "WWW"
-#: ./ftw/contentpage/content/addressblock.py:107
+#: ./ftw/contentpage/content/addressblock.py:114
 msgid "label_www"
 msgstr ""
 
 #. Default: "ZIP"
-#: ./ftw/contentpage/content/addressblock.py:59
+#: ./ftw/contentpage/content/addressblock.py:66
 msgid "label_zip"
 msgstr ""
 
@@ -529,7 +538,7 @@ msgid "review_state"
 msgstr ""
 
 #. Default: "Fax ${num}"
-#: ./ftw/contentpage/browser/address.pt:18
+#: ./ftw/contentpage/browser/address.pt:21
 msgid "text_fax"
 msgstr ""
 
@@ -545,7 +554,7 @@ msgid "text_path_and_area"
 msgstr ""
 
 #. Default: "Tel. ${num}"
-#: ./ftw/contentpage/browser/address.pt:11
+#: ./ftw/contentpage/browser/address.pt:14
 msgid "text_phone"
 msgstr ""
 

--- a/ftw/contentpage/profiles/default/metadata.xml
+++ b/ftw/contentpage/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>1300</version>
+    <version>1400</version>
     <dependencies>
         <dependency>profile-simplelayout.base:default</dependency>
         <dependency>profile-simplelayout.portlet.dropzone:default</dependency>

--- a/ftw/contentpage/profiles/default/types/ContentPage.xml
+++ b/ftw/contentpage/profiles/default/types/ContentPage.xml
@@ -28,6 +28,7 @@
         <element value="simplelayout" />
         <element value="simplelayout_summary" />
         <element value="authorities_view" />
+        <element value="tabbed_block_view" />
     </property>
     <alias from="(Default)" to="(dynamic view)" />
     <alias from="edit" to="atct_edit" />

--- a/ftw/contentpage/upgrades/configure.zcml
+++ b/ftw/contentpage/upgrades/configure.zcml
@@ -193,4 +193,23 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 1300 -> 1400 -->
+    <genericsetup:upgradeStep
+        title="Adds tabbed block view"
+        description=""
+        source="1300"
+        destination="1400"
+        handler="ftw.contentpage.upgrades.to1400.UpdateViews"
+        profile="ftw.contentpage:default"
+        />
+
+    <genericsetup:registerProfile
+        name="1400"
+        title="ftw.contentpage.upgrades.1400"
+        description=""
+        directory="profiles/1400"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
 </configure>

--- a/ftw/contentpage/upgrades/profiles/1400/types/ContentPage.xml
+++ b/ftw/contentpage/upgrades/profiles/1400/types/ContentPage.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="ContentPage"
+        meta_type="Factory-based Type Information with dynamic views"
+        i18n:domain="ftw.contentpage" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+  <property name="view_methods" purge="False">
+    <element value="tabbed_block_view" />
+  </property>
+</object>

--- a/ftw/contentpage/upgrades/to1400.py
+++ b/ftw/contentpage/upgrades/to1400.py
@@ -1,0 +1,10 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateViews(UpgradeStep):
+    """Add simplelayout_summary view
+    """
+
+    def __call__(self):
+        self.setup_install_profile(
+            'profile-ftw.contentpage.upgrades:1400')


### PR DESCRIPTION
I've added a view to display the blocks in a contentpage as tabs.
![bildschirmfoto-2013-07-02-um-14 38 56](https://f.cloud.github.com/assets/157533/736415/daa36678-e317-11e2-9e31-d7756009bec6.png)
@jone please take a look
