### PR TITLE
Add mimetypeicon to subjectlisting

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.4 (unreleased)
 ----------------
 
+- Add mimetype icon to subject-listing
+  [elioschmutz]
+
 - Fix subjects-vocabulary if we get unique values in case sensitive
   [elioschmutz]
 

--- a/ftw/contentpage/browser/subject_listing.pt
+++ b/ftw/contentpage/browser/subject_listing.pt
@@ -55,9 +55,13 @@
                                     <td>
                                         <ul class="subject-content">
                                             <li tal:repeat="brain subject/brains">
-                                                <a tal:content="brain/Title"
-                                                   tal:attributes="href brain/getURL"
-                                                   />
+                                                <a tal:attributes="href brain/getURL">
+                                                   <span tal:content="brain/Title" />
+                                                   <img alt="" class="subject-mimetype-icon"
+                                                       tal:define="icon python:view.get_mimetype_icon(brain)"
+                                                       tal:condition="icon"
+                                                       tal:attributes="src icon"/>
+                                                </a>
                                             </li>
                                         </ul>
                                     </td>

--- a/ftw/contentpage/browser/subject_listing.py
+++ b/ftw/contentpage/browser/subject_listing.py
@@ -92,6 +92,20 @@ class AlphabeticalSubjectListing(BrowserView):
         self.letter = name
         return self
 
+    def get_mimetype_icon(self, brain):
+        registry = getUtility(IRegistry)
+        if not registry['ftw.contentpage.subjectlisting.show_mimetype_icon']:
+            return None
+
+        icon = brain.getIcon
+
+        if not icon:
+            return None
+
+        portal_url = getToolByName(self.context, 'portal_url')
+
+        return '%s/%s' % (portal_url(), icon)
+
     @instance.memoize
     def get_current_letter(self):
         if self.letter is not None:

--- a/ftw/contentpage/profiles/default/metadata.xml
+++ b/ftw/contentpage/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>1401</version>
+    <version>1402</version>
     <dependencies>
         <dependency>profile-simplelayout.base:default</dependency>
         <dependency>profile-simplelayout.portlet.dropzone:default</dependency>

--- a/ftw/contentpage/profiles/default/registry.xml
+++ b/ftw/contentpage/profiles/default/registry.xml
@@ -44,5 +44,11 @@
             <element>ContentPage</element>
         </value>
     </record>
-
+    <record name="ftw.contentpage.subjectlisting.show_mimetype_icon">
+        <field type="plone.registry.field.Bool">
+            <title>Show the mimetype icon after the listed subject.</title>
+            <value_type type="plone.registry.field.Bool" />
+        </field>
+        <value>False</value>
+    </record>
 </registry>

--- a/ftw/contentpage/tests/pages.py
+++ b/ftw/contentpage/tests/pages.py
@@ -22,6 +22,10 @@ class SubjectListingView(Plone):
         return map(self._item_to_text,
                    browser().find_by_css('.letter-index a'))
 
+    @property
+    def mimetype_images(self):
+        return browser().find_by_css('.subject-mimetype-icon')
+
     def click_letter(self, letter):
         xpath = INDEX_XPATH + '//a[normalize-space(text())="%s"]' % letter
         elements = browser().find_by_xpath(xpath)

--- a/ftw/contentpage/tests/test_subject_listing.py
+++ b/ftw/contentpage/tests/test_subject_listing.py
@@ -197,3 +197,22 @@ class TestAlphabeticalSubjectListing(TestCase):
         self.assertEquals(
             'There is no content to list.',
             browser().find_by_css('#content .no-contents').text.strip())
+
+    def test_dont_show_mimetype_icon_per_default(self):
+        create(Builder('content page')
+               .titled('A page')
+               .having(subject=['budget']))
+
+        view = SubjectListingView().visit()
+        self.assertEquals([], view.mimetype_images)
+
+    def test_show_mimetype_icon_if_set_in_registry(self):
+        registry = getUtility(IRegistry)
+        registry['ftw.contentpage.subjectlisting.show_mimetype_icon'] = True
+
+        create(Builder('content page')
+               .titled('A page')
+               .having(subject=['budget']))
+
+        view = SubjectListingView().visit()
+        self.assertEquals(1, len(view.mimetype_images))

--- a/ftw/contentpage/upgrades/configure.zcml
+++ b/ftw/contentpage/upgrades/configure.zcml
@@ -231,4 +231,23 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 1401 -> 1402 -->
+    <genericsetup:upgradeStep
+        title="Add show_mimetype_icon for alphabetical subject listing"
+        description=""
+        source="1401"
+        destination="1402"
+        handler="ftw.contentpage.upgrades.to1402.UpdateRegistry"
+        profile="ftw.contentpage:default"
+        />
+
+    <genericsetup:registerProfile
+        name="1402"
+        title="ftw.contentpage.upgrades.1402"
+        description=""
+        directory="profiles/1402"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
 </configure>

--- a/ftw/contentpage/upgrades/profiles/1402/registry.xml
+++ b/ftw/contentpage/upgrades/profiles/1402/registry.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<registry>
+
+    <record name="ftw.contentpage.subjectlisting.show_mimetype_icon">
+        <field type="plone.registry.field.Bool">
+            <title>Show the mimetype icon after the listed subject.</title>
+            <value_type type="plone.registry.field.Bool" />
+        </field>
+        <value>False</value>
+    </record>
+
+</registry>

--- a/ftw/contentpage/upgrades/to1402.py
+++ b/ftw/contentpage/upgrades/to1402.py
@@ -1,0 +1,10 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateRegistry(UpgradeStep):
+    """Add show_mimetype_icon registry entry for alphabetical subject listing.
+    """
+
+    def __call__(self):
+        self.setup_install_profile(
+            'profile-ftw.contentpage.upgrades:1402')


### PR DESCRIPTION
@jone Can you take a look?
I added the mimetypeicon to the subjectlisting. Per default it's disabled. You can enable it over portal_registry:

![bildschirmfoto 2013-07-16 um 13 32 37](https://f.cloud.github.com/assets/557005/804354/795c7b4e-ee0b-11e2-8a2c-b137c93e9e5d.png)

![bildschirmfoto 2013-07-16 um 13 27 07](https://f.cloud.github.com/assets/557005/804355/795d1ae0-ee0b-11e2-8909-e8959571cecb.png)
