### PR TITLE
Subject listing: fix "#" letter.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Subject listing: fix "#" letter.
+  [jone]
 
 
 1.4 (2013-09-02)

--- a/ftw/contentpage/browser/subject_listing.pt
+++ b/ftw/contentpage/browser/subject_listing.pt
@@ -29,7 +29,7 @@
                             <li tal:repeat="letter view/letters">
                                 <a tal:condition="letter/has_contents"
                                    tal:attributes="class python:letter.get('current') and 'current';
-                                                   href string:${context/absolute_url}/@@subject-listing/${letter/label}"
+                                                   href letter/link"
                                    tal:content="letter/label"
                                    />
                                 <span tal:content="letter/label"

--- a/ftw/contentpage/browser/subject_listing.py
+++ b/ftw/contentpage/browser/subject_listing.py
@@ -80,16 +80,25 @@ class AlphabeticalSubjectListing(BrowserView):
         current_letter = self.get_current_letter()
 
         for letter in LETTERS:
+            if letter == '#':
+                character = '!'
+            else:
+                character = letter
             yield {'label': letter,
                    'has_contents': letter in letters_with_content,
-                   'link': '',
+                   'link': '/'.join((self.context.absolute_url(),
+                                     '@@subject-listing',
+                                     character)),
                    'current': letter == current_letter}
 
     def has_contents(self):
         return bool(len(self._letters_with_content))
 
     def publishTraverse(self, request, name):
-        self.letter = name
+        if name == '!':
+            self.letter = '#'
+        else:
+            self.letter = name
         return self
 
     def get_mimetype_icon(self, brain):


### PR DESCRIPTION
'#' in the URL does not really work because it is an anchor.
This PR changes the URL of '#' to use the character '!'

@elioschmutz please review
Fixes #113 
