### PR TITLE
Remove ISimpleLayoutCapable from news folder.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.5 (unreleased)
 ----------------
 
+- Remove ISimpleLayoutCapable from news folder.
+  News folder is not really a simplelayout container.
+  [jone]
+
 - Subject listing: fix "#" letter.
   [jone]
 

--- a/ftw/contentpage/content/newsfolder.py
+++ b/ftw/contentpage/content/newsfolder.py
@@ -3,7 +3,6 @@ from ftw.contentpage.config import PROJECTNAME
 from ftw.contentpage.interfaces import INewsFolder
 from Products.ATContentTypes.config import HAS_LINGUA_PLONE
 from Products.ATContentTypes.content import folder
-from simplelayout.base.interfaces import ISimpleLayoutCapable
 from zope.interface import implements
 
 
@@ -15,7 +14,7 @@ else:
 
 class NewsFolder(folder.ATFolder):
 
-    implements(INewsFolder, ISimpleLayoutCapable)
+    implements(INewsFolder)
     security = ClassSecurityInfo()
 
 


### PR DESCRIPTION
News folder is not really a simplelayout container.
Having the ISimpleLayoutCapable on the folder results in reindexing all containing
news items on every change on a news item (!) because the news items implement
the simplelayout block interface (because of the image).
This is a huge performance impact.

@elioschmutz you can merge this if you expierence no problem on your installation with productive data..
