### PR TITLE
Add document date to listing block if ftw.file is installed.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.5 (unreleased)
 ----------------
 
+- Add document date to listing block if ftw.file is installed.
+  [jone]
+
 - Fix extend_query_by_date function if 'datestring' contains a  bad date-format.
   The function is to extend a query (dict) with a daterange and returns the new
   query. If the function can't convert the datestring to a datetime object, it

--- a/ftw/contentpage/browser/listingblock_view.py
+++ b/ftw/contentpage/browser/listingblock_view.py
@@ -5,6 +5,15 @@ from ftw.table import helper
 from ftw.table.interfaces import ITableGenerator
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.component import queryUtility
+import pkg_resources
+
+
+try:
+    pkg_resources.get_distribution('ftw.file')
+except pkg_resources.DistributionNotFound:
+    HAS_FILE = False
+else:
+    HAS_FILE = True
 
 
 def download_link(icon=True, classes=None, attrs=None, icon_only=False):
@@ -64,6 +73,15 @@ class ListingBlockView(BrowserView):
              'sort_index': 'id',
              },
             )
+
+        if HAS_FILE:
+            columns += (
+                {'column': 'documentDate',
+                 'column_title': _(u'column_documen_date',
+                                   default=u'Document date'),
+                 'sort_index': 'documentDate',
+                 'transform': helper.readable_date},)
+
         return columns
 
     def block_visible(self):

--- a/ftw/contentpage/locales/de/LC_MESSAGES/ftw.contentpage.po
+++ b/ftw/contentpage/locales/de/LC_MESSAGES/ftw.contentpage.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-07-02 13:42+0000\n"
+"POT-Creation-Date: 2013-09-10 09:04+0000\n"
 "PO-Revision-Date: 2013-04-11 18:16+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -151,6 +151,14 @@ msgstr "Abbrechen"
 #: ./ftw/contentpage/browser/listingblock_view.py:49
 msgid "column_creater"
 msgstr "Ersteller"
+
+#. Default: "Document date"
+#: ./ftw/contentpage/browser/listingblock_view.py:80
+msgid "column_documen_date"
+msgstr "Dokumentdatum"
+
+msgid "label_documentDate"
+msgstr "Dokumentdatum"
 
 #. Default: "modified"
 #: ./ftw/contentpage/browser/listingblock_view.py:43

--- a/ftw/contentpage/locales/ftw.contentpage-manual.pot
+++ b/ftw/contentpage/locales/ftw.contentpage-manual.pot
@@ -26,6 +26,9 @@ msgstr ""
 msgid "label_id"
 msgstr ""
 
+msgid "label_documentDate"
+msgstr ""
+
 msgid "Address"
 msgstr ""
 

--- a/ftw/contentpage/locales/ftw.contentpage.pot
+++ b/ftw/contentpage/locales/ftw.contentpage.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-07-02 13:42+0000\n"
+"POT-Creation-Date: 2013-09-10 09:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -152,6 +152,14 @@ msgstr ""
 #. Default: "creater"
 #: ./ftw/contentpage/browser/listingblock_view.py:49
 msgid "column_creater"
+msgstr ""
+
+#. Default: "Document date"
+#: ./ftw/contentpage/browser/listingblock_view.py:80
+msgid "column_documen_date"
+msgstr ""
+
+msgid "label_documentDate"
 msgstr ""
 
 #. Default: "modified"


### PR DESCRIPTION
We need to be able to display `Document Date` in the listing block.
The `Document Date` is a custom field defined by `ftw.file` (which also registers an index and metadata).

This PR makes the `Document Date` available if `ftw.file` is installed.

![bildschirmfoto 2013-09-10 um 11 18 54](https://f.cloud.github.com/assets/7469/1113336/0b4afe80-19fa-11e3-8db7-22d0fd4d8b4f.png)

@elioschmutz please review
/cc @bbuehlmann 
