### PR TITLE
Fix extend_query_by_date function if it raises an error

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,13 @@ Changelog
 1.5 (unreleased)
 ----------------
 
+- Fix extend_query_by_date function if 'datestring' contains a  bad date-format.
+  The function is to extend a query (dict) with a daterange and returns the new
+  query. If the function can't convert the datestring to a datetime object, it
+  returns None and the given query is lost.
+  Now the function returns the untouched query.
+  [elio.schmutz]
+
 - Fix TypeError in news rss listing.
   [jone]
 

--- a/ftw/contentpage/browser/baselisting.py
+++ b/ftw/contentpage/browser/baselisting.py
@@ -9,7 +9,7 @@ def extend_query_by_date(query, datestring, date_field):
     try:
         start = DateTime(datestring)
     except dtSytaxError:
-        return
+        return query
     end = DateTime('%s/%s/%s' % (start.year() + start.month() / 12,
                                  start.month() % 12 + 1, 1))
     end = end - 1

--- a/ftw/contentpage/tests/test_news_views.py
+++ b/ftw/contentpage/tests/test_news_views.py
@@ -10,27 +10,19 @@ import unittest2 as unittest
 class TestExtendQueryByDate(unittest.TestCase):
 
     def test_extend_query_by_date(self):
-        query = {}
-        extend_query_by_date(query, '2012/12/01', 'effective')
+        query = extend_query_by_date({}, '2012/12/01', 'effective')
         self.assertEquals(
             {'effective':
-                 {'query': (DateTime('2012/12/01').earliestTime(),
-                            DateTime('2012/12/31').latestTime()),
-                  'range': 'minmax'}},
+                {'query': (
+                    DateTime('2012/12/01').earliestTime(),
+                    DateTime('2012/12/31').latestTime()),
+                    'range': 'minmax'}},
             query)
 
-        extend_query_by_date(query, '2013/02/01', 'effective')
-        self.assertEquals(
-            {'effective':
-                 {'query': (DateTime('2013/02/01').earliestTime(),
-                            DateTime('2013/02/28').latestTime()),
-                  'range': 'minmax'}},
-            query)
-
-        # fallback
-        query = {}
-        extend_query_by_date(query, 'not a date', 'effective')
-        self.assertEquals(query, {})
+    def test_query_does_not_lose_informations_if_date_is_incorrect(self):
+        query = extend_query_by_date(
+            {'Title': 'James'}, 'not a date', 'effective')
+        self.assertEquals(query, {'Title': 'James'})
 
 
 class TestNewsViews(unittest.TestCase):


### PR DESCRIPTION
@jone 
- Fix extend_query_by_date function if 'datestring' contains a  bad date-format.
  The function is to extend a query (dict) with a daterange and returns the new
  query. If the function can't convert the datestring to a datetime object, it
  returns None and the given query is lost.
  Now the function returns the untouched query.
- Also fix the bad test for this case.
