### PR TITLE
Implement subject_filter functionality for subject_listing view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,11 @@ Changelog
 1.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Implement subject_filter for subject_listing view.
+  It's possible to add a request filter (?subject_filter=Law) if you wish
+  to display just objects with the filtered subject. The filtered subject itself
+  will not be displayed in the listing.
+  [elioschmutz]
 
 
 1.5.2 (2013-11-04)

--- a/ftw/contentpage/tests/pages.py
+++ b/ftw/contentpage/tests/pages.py
@@ -50,6 +50,11 @@ class SubjectListingView(Plone):
     def _item_to_text(self, item):
         return self.normalize_whitespace(item.text.strip())
 
+    def visit_with_subject_filter(self, value):
+        self.visit_portal('@@subject-listing?subject_filter={0}'.format(value))
+        self.assert_body_class('template-subject-listing')
+        return self
+
 
 class AuthoritiesView(Plone):
 


### PR DESCRIPTION
@maethu @buchi 

Updated the subject_listing view.

You can add a var in manage_propertiesForm or you can add a request variable:

name: subject_listing
value: string

The view will display just objects related to this subject:

Defaultview:

![bildschirmfoto 2013-11-08 um 14 39 32](https://f.cloud.github.com/assets/557005/1500603/3e234ed4-487b-11e3-8c05-5b70bf2bd0d9.png)

With subject_filter:

![bildschirmfoto 2013-11-08 um 14 39 17](https://f.cloud.github.com/assets/557005/1500607/525e36f2-487b-11e3-8572-e3f2278382bd.png)
