### PR TITLE
Show inactive content in news and event listings if the user has permiss...

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.5.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Show inactive content in news and event listings if the user has permission to
+  access inactive contents on the local context.
+  [buchi]
 
 
 1.5.3 (2013-11-12)

--- a/ftw/contentpage/browser/baselisting.py
+++ b/ftw/contentpage/browser/baselisting.py
@@ -3,6 +3,9 @@ from DateTime.interfaces import SyntaxError as dtSytaxError
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.PloneBatch import Batch
 from zope.publisher.browser import BrowserView
+from Products.CMFCore.utils import _checkPermission
+from Products.CMFCore.permissions import AccessInactivePortalContent
+
 
 
 def extend_query_by_date(query, datestring, date_field):
@@ -57,9 +60,11 @@ class BaseListing(BrowserView):
         if ct == 'Topic':
             return context.queryCatalog()
         else:
+            show_inactive = _checkPermission(AccessInactivePortalContent,
+                                             context)
             catalog = getToolByName(context, 'portal_catalog')
             query['path'] = '/'.join(context.getPhysicalPath())
-            return catalog(query)
+            return catalog(query, show_inactive=show_inactive)
 
     def has_img(self, brain):
         """ Checks if the news have an image.


### PR DESCRIPTION
...ion to access inactive contents on the local context.

The default behavior of Plone is to only show inactive content to users having the "Access inactive portal content" permission on the portal root. This is not practical for user having only local roles for content creation. If they create a content with an effective date in the future, they no longer see this content. This workaround allows them to see inactive content in news and event listings.
