### PR TITLE
encode Reply-To correctly

### DIFF
--- a/ftw/contentpage/browser/feedback.py
+++ b/ftw/contentpage/browser/feedback.py
@@ -85,11 +85,10 @@ class FeedbackForm(form.Form):
 
         msg['From'] = Header('%s' % portal.getProperty('email_from_name'),
                              'utf-8')
-        msg['From'].append("<%s>" % portal.getProperty('email_from_address'))
+        msg['From'].append("<%s>" % portal.getProperty('email_from_address').decode('utf-8'))
         msg['Reply-To'] = Header("%s" % sender, 'utf-8')
         msg['Reply-To'].append("<%s>" % recipient)
         msg['To'] = self.context.getEmail()
-
         # send the message
         mh.send(msg)
 

--- a/ftw/contentpage/tests/test_feedback_form.py
+++ b/ftw/contentpage/tests/test_feedback_form.py
@@ -96,13 +96,12 @@ class TestFeedbackForm(MockTestCase):
         self.assertEquals(len(self.mails), 1)
 
         args, kwargs = self.mails.pop()
-
         self.assertIn('=?utf-8?q?Don=27t_p=C3=A4nic?=', args[0].__str__())
         self.assertIn(FORM_DATA['message'], args[0].__str__())
         self.assertIn(
             'Reply-To: =?utf-8?q?Zaph=C3=B6d_Beeblebrox?= <z.beeblebrox@endofworld.com>',
             args[0].__str__())
-        self.assertIn('From: Plone Admin <plone@admin.ch>', args[0].__str__())
+        self.assertIn('From: =?utf-8?q?Plone_Admin?= <plone@admin.ch>', args[0].__str__())
 
     def tearDown(self):
         super(TestFeedbackForm, self).tearDown()


### PR DESCRIPTION
@buchi @maethu can you take a look at this this fixes the mess with the reply-to address in the feedback forms.
Before:
![unbenannt2](https://f.cloud.github.com/assets/358342/1643971/63569fb8-58d8-11e3-917e-7439fb0558e7.JPG)

After:
![unbenannt-1](https://f.cloud.github.com/assets/358342/1643970/634137c2-58d8-11e3-9a5b-0a8fba508cc9.JPG)
