### PR TITLE
Added possibility to create an event with a start time, but no end time.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,11 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
+- Added possibility to create an event with a start time, but no end time.
+  If you set the start and end at the same date and time, the output will be
+  "01.01.2014 08:00" instead of "01.01.2014 08:00 - 08:00".
+  [Julian Infanger]
+
 - Move anchor above title so the title is visible when the anchor is used.
   [tschanzt]
 

--- a/ftw/contentpage/browser/eventlisting.py
+++ b/ftw/contentpage/browser/eventlisting.py
@@ -17,6 +17,8 @@ def format_date(start, end, wholeday):
             return start_date
         return '%s - %s' % (start_date, end_date)
     if start_date == end_date:
+        if start_time == end_time:
+            return '%s %s' % (start_date, start_time)
         return '%s %s - %s' % (start_date, start_time, end_time)
     return '%s %s - %s %s' % (
           start_date, start_time, end_date, end_time)

--- a/ftw/contentpage/tests/test_event_date.py
+++ b/ftw/contentpage/tests/test_event_date.py
@@ -36,3 +36,11 @@ class TestEvent(unittest.TestCase):
 
         self.assertEquals(format_date(start, end, wholeday),
             '01.01.2013 - 03.01.2013')
+
+    def test_same_data_same_time(self):
+        start = DateTime(2013, 01, 01, 11, 00)
+        end = DateTime(2013, 01, 01, 11, 00)
+        wholeday = False
+
+        self.assertEquals(format_date(start, end, wholeday),
+            '01.01.2013 11:00')


### PR DESCRIPTION
If you set the start and end at the same date and time, the output will be "01.01.2014 08:00" instead of "01.01.2014 08:00 - 08:00".
@elioschmutz 
