### PR TITLE
Fix mutable bug in finalize schema function.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
+- Fix mutable bug in finalize schema function.
+  [jone]
+
 - EventPage: Updated event data table markup.
   [Julian Infanger]
 

--- a/ftw/contentpage/content/listingblock.py
+++ b/ftw/contentpage/content/listingblock.py
@@ -76,7 +76,7 @@ schemata.finalizeATCTSchema(
 listing_block_schema['title'].required = False
 listing_block_schema['title'].default_method = 'getDefaultTitle'
 
-finalize(listing_block_schema)
+finalize(listing_block_schema, hide=['description'])
 
 
 class ListingBlock(folder.ATFolder):

--- a/ftw/contentpage/content/schema.py
+++ b/ftw/contentpage/content/schema.py
@@ -11,7 +11,7 @@ DEFAULT_TO_HIDE = [
 
 
 def finalize(schema, show=None, hide=None):
-    to_hide = DEFAULT_TO_HIDE
+    to_hide = DEFAULT_TO_HIDE[:]
     if hide:
         to_hide += hide
 

--- a/ftw/contentpage/content/textblock.py
+++ b/ftw/contentpage/content/textblock.py
@@ -89,11 +89,9 @@ textblock_schema = ATContentTypeSchema.copy() + \
     default_schema.copy() + image_schema.copy()
 
 textblock_schema['title'].required = False
-textblock_schema['description'].widget.visible = {'view': 'invisible',
-                                                  'edit': 'invisible'}
 textblock_schema['text'].widget.filter_buttons = ('image', )
 
-finalize(textblock_schema)
+finalize(textblock_schema, hide=['description'])
 
 
 class TextBlock(ATCTContent, HistoryAwareMixin):


### PR DESCRIPTION
Fixes a bug in finalize schema function, which caused to "persist" additional fields to hide and apply them to all following schemas.

Also made the `description` of listing block hidden, since this kind of relied on the buggy mutable behavior.
Also applied the same method to the textblock schema, so that we have consistency.

@maethu 
