### PR TITLE
Updated markup for event data table.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- EventPage: Updated event data table markup.
+  [Julian Infanger]
 
 
 1.6.1 (2014-03-10)

--- a/ftw/contentpage/browser/resources/contentpage.css
+++ b/ftw/contentpage/browser/resources/contentpage.css
@@ -110,6 +110,16 @@ body.template-tabbed_block_view .slAlignBlocks {
 
 /* @end */
 
+/* @group event data table */
+
+div.eventData {
+  float: right;
+  margin-top: 1em;
+  margin-left: 1em;
+}
+
+/* @end */
+
 
 /* @group alphabetical subject listing */
 

--- a/ftw/contentpage/locales/de/LC_MESSAGES/ftw.contentpage.po
+++ b/ftw/contentpage/locales/de/LC_MESSAGES/ftw.contentpage.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-01-22 14:49+0000\n"
+"POT-Creation-Date: 2014-03-24 15:25+0000\n"
 "PO-Revision-Date: 2013-04-11 18:16+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -69,13 +69,17 @@ msgstr "Veranstaltungsordner"
 msgid "Events"
 msgstr "Veranstaltungen"
 
+#: ./ftw/contentpage/viewlets/event_data.pt:16
+msgid "Export"
+msgstr "Exportieren"
+
 #: ./ftw/contentpage/profiles/default/types/AddressBlock.xml
 #: ./ftw/contentpage/profiles/default/types/ListingBlock.xml
 #: ./ftw/contentpage/profiles/default/types/TextBlock.xml
 msgid "External Edit"
 msgstr "Mit externem Editor bearbeiten"
 
-#: ./ftw/contentpage/viewlets/event_data.pt:18
+#: ./ftw/contentpage/viewlets/event_data.pt:19
 msgid "ICS-Export"
 msgstr "ICS-Export"
 
@@ -604,4 +608,3 @@ msgstr "Sie k√∂nnen keinen Pfad definieren und gleichzeitig den Bereich einschr√
 #: ./ftw/contentpage/browser/address.pt:14
 msgid "text_phone"
 msgstr "Tel. ${num}"
-

--- a/ftw/contentpage/locales/ftw.contentpage.pot
+++ b/ftw/contentpage/locales/ftw.contentpage.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-01-22 14:49+0000\n"
+"POT-Creation-Date: 2014-03-24 15:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -72,13 +72,17 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
+#: ./ftw/contentpage/viewlets/event_data.pt:16
+msgid "Export"
+msgstr ""
+
 #: ./ftw/contentpage/profiles/default/types/AddressBlock.xml
 #: ./ftw/contentpage/profiles/default/types/ListingBlock.xml
 #: ./ftw/contentpage/profiles/default/types/TextBlock.xml
 msgid "External Edit"
 msgstr ""
 
-#: ./ftw/contentpage/viewlets/event_data.pt:18
+#: ./ftw/contentpage/viewlets/event_data.pt:19
 msgid "ICS-Export"
 msgstr ""
 

--- a/ftw/contentpage/tests/test_event_views.py
+++ b/ftw/contentpage/tests/test_event_views.py
@@ -125,22 +125,24 @@ class TestEventListing(MockTestCase):
         self.browser.open(event1.absolute_url())
         query = PyQuery(self.browser.contents)
         elements = query('.eventdata tr th')
-        self.assertEqual(len(elements), 1)
+        self.assertEqual(len(elements), 2)
         self.assertEqual(elements[0].text.strip(), 'Date')
+        self.assertEqual(elements[1].text.strip(), 'Export')
 
         self.browser.open(event2.absolute_url())
         query = PyQuery(self.browser.contents)
         elements = query('.eventdata tr th')
-        self.assertEqual(len(elements), 2)
+        self.assertEqual(len(elements), 3)
         self.assertEqual(elements[0].text.strip(), 'Date')
         self.assertEqual(elements[1].text.strip(), 'Location')
-        location = query('.eventdata tr td')[-1]
+        self.assertEqual(elements[2].text.strip(), 'Export')
+        location = query('.eventdata tr td')[-2]
         self.assertEqual(location.text, event2.getLocation())
-        
+
     def test_event_data_viewlet(self):
         event = self.eventfolder.get('event3')  # has an image
         view = BrowserView(event, event.REQUEST)
-        manager_name = 'plone.abovecontentbody'
+        manager_name = 'plone.abovecontenttitle'
         manager = queryMultiAdapter((event, event.REQUEST, view),
             IViewletManager,
             manager_name)

--- a/ftw/contentpage/viewlets/configure.zcml
+++ b/ftw/contentpage/viewlets/configure.zcml
@@ -43,7 +43,7 @@
     <browser:viewlet
         for="ftw.contentpage.interfaces.IEventPage"
         name="ftw.contentpage.event.eventdata"
-        manager="plone.app.layout.viewlets.interfaces.IAboveContentBody"
+        manager="plone.app.layout.viewlets.interfaces.IAboveContentTitle"
         class=".event_data.EventDataViewlet"
         permission="zope2.View"
         layer="ftw.contentpage.interfaces.IFtwContentPageLayer"

--- a/ftw/contentpage/viewlets/event_data.pt
+++ b/ftw/contentpage/viewlets/event_data.pt
@@ -1,4 +1,4 @@
-<div i18n:domain="ftw.contentpage">
+<div i18n:domain="ftw.contentpage" class="eventData">
   <table class="vertical plain eventdata">
     <tr tal:condition="context/start">
       <th i18n:translate="">
@@ -12,10 +12,13 @@
       </th>
       <td tal:content="location" />
     </tr>
+    <tr class="exportRow">
+      <th i18n:translate="">Export</th>
+      <td>
+        <img tal:attributes="src string: ${context/portal_url}/icon_export_ical.png" />
+        <a tal:attributes="href string: ${context/absolute_url}/ics_view" i18n:translate="">ICS-Export</a>
+      </td>
+    </tr>
   </table>
-  <div>
-    <img tal:attributes="src string: ${context/portal_url}/icon_export_ical.png" />
-    <a tal:attributes="href string: ${context/absolute_url}/ics_view" i18n:translate="">ICS-Export</a>
-  </div>
 
 </div>


### PR DESCRIPTION
## from
## ![bildschirmfoto 2014-03-24 um 16 31 27](https://f.cloud.github.com/assets/157533/2501176/850f5b7c-b369-11e3-9f63-a82f8e3ab9ff.png)

![bildschirmfoto 2014-03-24 um 16 31 40](https://f.cloud.github.com/assets/157533/2501178/850f9cb8-b369-11e3-9194-5152e4e3bfda.png)
## to
## ![bildschirmfoto 2014-03-24 um 16 30 20](https://f.cloud.github.com/assets/157533/2501177/850f850c-b369-11e3-8edd-fdd52e299e38.png)

![bildschirmfoto 2014-03-24 um 16 30 31](https://f.cloud.github.com/assets/157533/2501175/850f231e-b369-11e3-8388-4c04bb2035f0.png)
