### PR TITLE
Enable openlayer resources on IContentPage if an AddressBlock is available.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
+- Enable openlayer resources on IContentPage if an AddressBlock is available.
+  Marking the ContentPage as IAuthorty is no longer necessary.
+  [mathias.leimgruber]
+
 - Add upgradestep for collapse_archive.js registration
   [elioschmutz]
 

--- a/ftw/contentpage/viewlets/configure.zcml
+++ b/ftw/contentpage/viewlets/configure.zcml
@@ -51,7 +51,7 @@
 
     <browser:viewlet
         name="ftw.contentpage.openlayers"
-        for="ftw.contentpage.interfaces.IAuthority"
+        for="ftw.contentpage.interfaces.IContentPage"
         manager="plone.app.layout.viewlets.interfaces.IHtmlHeadLinks"
         class=".openlayers.OpenlayersViewlet"
         permission="zope2.View"

--- a/ftw/contentpage/viewlets/openlayers.pt
+++ b/ftw/contentpage/viewlets/openlayers.pt
@@ -1,6 +1,8 @@
 <html
     xml:lang="en"
     xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:metal="http://xml.zope.org/namespaces/metal">
+    xmlns:metal="http://xml.zope.org/namespaces/metal"
+    tal:omit-tag=""
+    tal:condition="view/available">
     <metal:use use-macro="context/@@collectivegeo-macros/openlayers"/>
 </html>

--- a/ftw/contentpage/viewlets/openlayers.py
+++ b/ftw/contentpage/viewlets/openlayers.py
@@ -1,6 +1,10 @@
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone.app.layout.viewlets.common import ViewletBase
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 
 class OpenlayersViewlet(ViewletBase):
     index = ViewPageTemplateFile('openlayers.pt')
+
+    def available(self):
+        return bool(self.context.getFolderContents({
+            'portal_type': 'AddressBlock'}))


### PR DESCRIPTION
Marking the ContentPage as IAuthorty is no longer necessary
