### PR TITLE
Move eventdata table below the description.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.6.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Move eventdata table below the description.
+  [Julian Infanger]
 
 
 1.6.4 (2014-04-16)

--- a/ftw/contentpage/browser/resources/contentpage.css
+++ b/ftw/contentpage/browser/resources/contentpage.css
@@ -113,9 +113,7 @@ body.template-tabbed_block_view .slAlignBlocks {
 /* @group event data table */
 
 div.eventData {
-  float: right;
   margin-top: 1em;
-  margin-left: 1em;
 }
 
 /* @end */

--- a/ftw/contentpage/tests/test_event_views.py
+++ b/ftw/contentpage/tests/test_event_views.py
@@ -142,7 +142,7 @@ class TestEventListing(MockTestCase):
     def test_event_data_viewlet(self):
         event = self.eventfolder.get('event3')  # has an image
         view = BrowserView(event, event.REQUEST)
-        manager_name = 'plone.abovecontenttitle'
+        manager_name = 'plone.abovecontentbody'
         manager = queryMultiAdapter((event, event.REQUEST, view),
             IViewletManager,
             manager_name)

--- a/ftw/contentpage/viewlets/configure.zcml
+++ b/ftw/contentpage/viewlets/configure.zcml
@@ -43,7 +43,7 @@
     <browser:viewlet
         for="ftw.contentpage.interfaces.IEventPage"
         name="ftw.contentpage.event.eventdata"
-        manager="plone.app.layout.viewlets.interfaces.IAboveContentTitle"
+        manager="plone.app.layout.viewlets.interfaces.IAboveContentBody"
         class=".event_data.EventDataViewlet"
         permission="zope2.View"
         layer="ftw.contentpage.interfaces.IFtwContentPageLayer"


### PR DESCRIPTION
I just realized it was not the best way to move the event data table right to the title.
This causes several problems: right floated images doesn't work anymore, the description has not enough space, ....
So I think it's the best way to keep the table styled this way but display it below the description:

**FROM**
![bildschirmfoto 2014-04-15 um 11 24 34](https://cloud.githubusercontent.com/assets/157533/2705529/c92cedde-c47f-11e3-9511-bb1bb8d55a70.png)

**TO**
![bildschirmfoto 2014-04-15 um 11 22 41](https://cloud.githubusercontent.com/assets/157533/2705528/c916a8d0-c47f-11e3-954c-953906b4a0aa.png)

@maethu 
