### PR TITLE
encode sender with utf-8

### DIFF
--- a/ftw/contentpage/browser/feedback.py
+++ b/ftw/contentpage/browser/feedback.py
@@ -86,6 +86,8 @@ class FeedbackForm(form.Form):
         msg['From'] = Header('%s' % portal.getProperty('email_from_name'),
                              'utf-8')
         msg['From'].append("<%s>" % portal.getProperty('email_from_address').decode('utf-8'))
+        if isinstance(sender, unicode):
+            sender = sender.encode('utf-8')
         msg['Reply-To'] = Header("%s" % sender, 'utf-8')
         msg['Reply-To'].append("<%s>" % recipient)
         msg['To'] = self.context.getEmail()

--- a/ftw/contentpage/tests/test_feedback_form.py
+++ b/ftw/contentpage/tests/test_feedback_form.py
@@ -103,6 +103,29 @@ class TestFeedbackForm(MockTestCase):
             args[0].__str__())
         self.assertIn('From: =?utf-8?q?Plone_Admin?= <plone@admin.ch>', args[0].__str__())
 
+    def test_encode_replyto_always(self):
+        """Test that tests if Reply-To header is always encoded."""
+        self._auth()
+        self.browser.open(self.form)
+        self.browser.getControl(
+            name="form.widgets.sender").value = 'Hans, Peter'
+        self.browser.getControl(
+            name="form.widgets.email").value = FORM_DATA['email']
+        self.browser.getControl(
+            name="form.widgets.subject").value = FORM_DATA['subject']
+        self.browser.getControl(
+            name="form.widgets.message").value = FORM_DATA['message']
+
+        self.browser.getControl('Send Mail').click()
+
+        self.assertEqual(self.browser.url,
+                         self.contentpage.absolute_url())
+
+        args, kwargs = self.mails.pop()
+        self.assertIn(
+            'Reply-To: =?utf-8?q?Hans=2C_Peter?= <z.beeblebrox@endofworld.com>',
+            args[0].__str__())
+        
     def tearDown(self):
         super(TestFeedbackForm, self).tearDown()
         portal = self.layer['portal']


### PR DESCRIPTION
@maethu This encodes the sender with utf-8.
I do this because the Header class if given a unicode string tries to encode it in ascii first and only then encodes it with our given charset. Since ascii is treated like no encoding, we have problems with chars that have special meanings in the reply-to header(i.e. comma which is use is used for spliting addresses).

 We now solve this problem by making the sender a bytestring because this way the Header class treats the charset we give it as encoding of the given string and always encodes it with this encoding. When this happens, the caracters loose their special meaning and get treated as normal chars which is what we want.
