### PR TITLE
Textblock simplelayout view: support text blocks without image.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.6.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Textblock simplelayout view: support text blocks without image.
+  [jone]
 
 
 1.6.6 (2014-06-11)

--- a/ftw/contentpage/browser/textblock_view.pt
+++ b/ftw/contentpage/browser/textblock_view.pt
@@ -7,7 +7,8 @@
                      style string:${view/get_block_height}">
      <a tal:attributes="name here/id" ></a>
     <h2 tal:content="here/Title" tal:condition="here/getShowTitle|python:True" />
-        <div class="sl-img-wrapper" tal:condition="view/has_image"
+    <tal:IMAGE tal:condition="view/has_image">
+        <div class="sl-img-wrapper"
              tal:attributes="style view/image_wrapper_style"
              tal:define="image_desc context/getImageCaption | context/Description">
                     <a  tal:attributes="
@@ -20,7 +21,8 @@
                     </a>
                     <p tal:condition="image_desc"
                        tal:content="context/getImageCaption">Caption</p>
-    </div>
+        </div>
+    </tal:IMAGE>
     <div tal:condition="text" class="sl-text-wrapper" tal:content="structure text"></div>
 </div>
 <div class="visualClear"><!-- --></div>

--- a/ftw/contentpage/browser/textblock_view.py
+++ b/ftw/contentpage/browser/textblock_view.py
@@ -17,10 +17,15 @@ class TextBlockView(BrowserView):
         self.image_layout = self.blockconf.image_layout
 
     def get_css_klass(self):
+        if not self.has_image():
+            return ''
+
         layout = self.image_layout
         return 'sl-img-' + layout
 
     def has_image(self):
+        if 'image' not in self.context.Schema():
+            return False
         return bool(self.context.getImage())
 
     def get_image_tag(self):


### PR DESCRIPTION
This makes it possible to reuse the block view without images.
// @maethu 
