### PR TITLE
Fix eventlisting. Shows events based on the end date

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.6.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix eventlisting. Shows events based on the end date
+  instead the start date
+  [elioschmutz]
 
 
 1.6.8 (2014-06-13)

--- a/ftw/contentpage/browser/eventlisting.py
+++ b/ftw/contentpage/browser/eventlisting.py
@@ -36,7 +36,7 @@ class EventListing(BaseListing):
         query = {'path': '/'.join(self.context.getPhysicalPath()),
                  'portal_type': 'EventPage',
                  'sort_on': 'start',
-                 'start': {'query': DateTime(), 'range': 'min'}
+                 'end': {'query': DateTime(), 'range': 'min'}
                  }
         return self.search_results(query, 'start')
 

--- a/ftw/contentpage/tests/test_event_views.py
+++ b/ftw/contentpage/tests/test_event_views.py
@@ -1,14 +1,42 @@
-from Products.Five.browser import BrowserView
+from DateTime import DateTime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.contentpage.browser.eventlisting import EventListing
 from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
+from ftw.contentpage.testing import FTW_CONTENTPAGE_INTEGRATION_TESTING
 from ftw.testing import MockTestCase
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.testing.z2 import Browser
+from Products.Five.browser import BrowserView
 from pyquery import PyQuery
+from unittest2 import TestCase
 from zope.component import queryMultiAdapter
 from zope.viewlet.interfaces import IViewletManager
 import os
 import transaction
+
+
+class TestEventListingIntegration(TestCase):
+
+    layer = FTW_CONTENTPAGE_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+
+    def test_pending_events_are_still_visible(self):
+        folder = create(Builder('event folder'))
+        event = create(Builder('event page').within(folder).having(
+            startDate=DateTime()-1,
+            endDate=DateTime()+1)
+        )
+
+        view = EventListing(folder, self.request)
+
+        self.assertEqual(
+            [event],
+            [brain.getObject() for brain in view.get_items()])
 
 
 class TestEventListing(MockTestCase):


### PR DESCRIPTION
@maethu Fix eventlisting. Shows events based on the end date instead the start date

closes: #160 
