### PR TITLE
Show description in listingblock colorbox.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Show description in listingblock colorbox.
+  [Julian Infanger]
 
 
 1.7.1 (2014-07-16)

--- a/ftw/contentpage/browser/listingblock_gallery_view.pt
+++ b/ftw/contentpage/browser/listingblock_gallery_view.pt
@@ -12,7 +12,7 @@
           <div class="frame sl-img-wrapper"
                tal:attributes="style string:width:${width};;height:${height}">
             <a href="#"
-               tal:attributes="title img/title_or_id;
+               tal:attributes="title img/Description;
                                href img/absolute_url">
               <img tal:replace="structure img/@@images/image/listingblock_gallery" />
             </a>

--- a/ftw/contentpage/browser/resources/contentpage.css
+++ b/ftw/contentpage/browser/resources/contentpage.css
@@ -123,6 +123,16 @@ div.eventData {
 
 /* @end */
 
+/* @group colorbox */
+
+#cboxTitle {
+  padding-left: 0.5em;
+  background: #FFF;
+  background: rgba(255, 255, 255, 0.8);
+}
+
+
+/* @end */
 
 /* @group alphabetical subject listing */
 


### PR DESCRIPTION
...instead of title
![bildschirmfoto 2014-07-21 um 13 45 26](https://cloud.githubusercontent.com/assets/157533/3643042/b1319bfa-10cc-11e4-8937-9bc83ac8b0f6.png)
