### PR TITLE
Listingblock title returns None

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.7.3 (unreleased)
 ------------------
 
+- Addressblock: Return an empty string if defaulttitle is none.
+  [Julian Infanger]
+
 - Feedback form: Replace comma in sender name.
   To avoid conflicts with reply-to address.
   [Julian Infanger]

--- a/ftw/contentpage/content/listingblock.py
+++ b/ftw/contentpage/content/listingblock.py
@@ -98,7 +98,8 @@ class ListingBlock(folder.ATFolder):
     security.declarePrivate('getDefaultTitle')
     def getDefaultTitle(self):
         registry = getUtility(IRegistry)
-        return registry.get('ftw.contentpage.listingblock.defaulttitle', '')
+        return registry.get(
+            'ftw.contentpage.listingblock.defaulttitle', None) or ''
 
     security.declarePrivate('getDefaultTableColumns')
     def getDefaultTableColumns(self):

--- a/ftw/contentpage/tests/test_listingblock_creation.py
+++ b/ftw/contentpage/tests/test_listingblock_creation.py
@@ -58,7 +58,7 @@ class TestListingBlockCreation(TestCase):
     def test_default_title(self):
         listingblock = self._create_listingblock()
         # Default is empty
-        self.assertEquals(None, listingblock.Title())
+        self.assertEquals('', listingblock.Title())
 
     def test_can_set_default_page(self):
         listingblock = self._create_listingblock()


### PR DESCRIPTION
The default title of the listingblock returns None.
Some packages (like collective.opengraph) can't handle this.

There is a default value '' defined in getDefaultTitle-Method:

``` python
return registry.get('ftw.contentpage.listingblock.defaulttitle', '')
```

but this returns only '' if the key 'ftw.contentpage.listingblock.defaulttitle' does not exists. In our case, the key do exists with the value None. So the default value '' will be ignored.

It should be something like

``` python
value = registry.get('ftw.contentpage.listingblock.defaulttitle', None)
return value and value or ''
```

The default title in the registry is set like this:

``` xml
    <record name="ftw.contentpage.listingblock.defaulttitle">
        <field type="plone.registry.field.TextLine">
            <title>Default title of a listingblock</title>
            <required>False</required>
        </field>
        <value></value>
    </record>
```
