### PR TITLE
feedbackview with comma in sender-Attribute

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.7.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Feedback form: Replace comma in sender name.
+  To avoid conflicts with reply-to address.
+  [Julian Infanger]
 
 
 1.7.2 (2014-07-28)

--- a/ftw/contentpage/browser/feedback.py
+++ b/ftw/contentpage/browser/feedback.py
@@ -48,7 +48,7 @@ class FeedbackForm(form.Form):
         message = data.get('message')
         email = data.get('email')
         subject = data.get('subject')
-        sender = data.get('sender')
+        sender = data.get('sender').replace(',', ' ')
         self.send_feedback(email, subject, message, sender)
         msg = _(u'info_email_sent', default=u'The email was sent.')
         IStatusMessage(self.request).addStatusMessage(msg, type='info')

--- a/ftw/contentpage/tests/test_feedback_form.py
+++ b/ftw/contentpage/tests/test_feedback_form.py
@@ -108,7 +108,7 @@ class TestFeedbackForm(MockTestCase):
         self._auth()
         self.browser.open(self.form)
         self.browser.getControl(
-            name="form.widgets.sender").value = 'Hans, Peter'
+            name="form.widgets.sender").value = 'Hans: Peter'
         self.browser.getControl(
             name="form.widgets.email").value = FORM_DATA['email']
         self.browser.getControl(
@@ -123,9 +123,28 @@ class TestFeedbackForm(MockTestCase):
 
         args, kwargs = self.mails.pop()
         self.assertIn(
-            'Reply-To: =?utf-8?q?Hans=2C_Peter?= <z.beeblebrox@endofworld.com>',
+            'Reply-To: =?utf-8?q?Hans=3A_Peter?= <z.beeblebrox@endofworld.com>',
             args[0].__str__())
-        
+
+    def test_comma_in_sender_name_will_be_replaced(self):
+        self._auth()
+        self.browser.open(self.form)
+        self.browser.getControl(
+            name="form.widgets.sender").value = 'Zaph\xc3\xb6d,Beeblebrox'
+        self.browser.getControl(
+            name="form.widgets.email").value = FORM_DATA['email']
+        self.browser.getControl(
+            name="form.widgets.subject").value = FORM_DATA['subject']
+        self.browser.getControl(
+            name="form.widgets.message").value = FORM_DATA['message']
+
+        self.browser.getControl('Send Mail').click()
+
+        args, kwargs = self.mails.pop()
+        self.assertIn(
+            'Reply-To: =?utf-8?q?Zaph=C3=B6d_Beeblebrox?= <z.beeblebrox@endofworld.com>',
+            args[0].__str__())
+
     def tearDown(self):
         super(TestFeedbackForm, self).tearDown()
         portal = self.layer['portal']


### PR DESCRIPTION
@maethu Reply to a received Email over the Addressblock-Feedbackview fails if the Visitor entered a Name with a comma.

![bildschirmfoto 2014-04-15 um 13 42 19](https://cloud.githubusercontent.com/assets/557005/2706538/17c7f0de-c493-11e3-9a49-3a2b3f74c9dc.png)

![bildschirmfoto 2014-04-15 um 13 42 30](https://cloud.githubusercontent.com/assets/557005/2706537/17c7a070-c493-11e3-9868-53e9858865d4.png)

![bildschirmfoto 2014-04-15 um 13 42 37](https://cloud.githubusercontent.com/assets/557005/2706539/17c9d516-c493-11e3-9452-129506ccd890.png)
