### PR TITLE
Addressblock: Activate WYSIWYG-Editor on directions and opening hours.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.7.3 (unreleased)
 ------------------
 
+- Addressblock: Activate WYSIWYG-Editor on directions and opening hours.
+  [lknoepfel]
+
 - Use ftw.profilehook instead of custom import steps (setuphandlers).
   [jone]
 

--- a/ftw/contentpage/browser/address.pt
+++ b/ftw/contentpage/browser/address.pt
@@ -36,11 +36,11 @@
 
   <tal:openingHours tal:condition="context/getShowOpeningHours">
     <h2 i18n:translate="label_openingHours">Opening Hours</h2>
-    <p tal:content="structure view/get_opening_hours_as_html"></p>
+    <p tal:content="structure context/getOpeningHours"></p>
   </tal:openingHours>
 
   <tal:block tal:condition="context/getDirections">
       <h2 i18n:translate="label_directions">Directions</h2>
-      <p tal:content="structure view/get_directions_as_html"></p>
+      <p tal:content="structure context/getDirections"></p>
   </tal:block>
 </tal:block>

--- a/ftw/contentpage/browser/addressblock_view.py
+++ b/ftw/contentpage/browser/addressblock_view.py
@@ -18,16 +18,6 @@ class AddressBlockView(BrowserView):
             html.append(self.context.getExtraAddressLine())
         return '<br />'.join(html)
 
-    def get_opening_hours_as_html(self):
-        """returns the opening hours as html
-        """
-        return self.context.getOpeningHours().replace('\n', '<br />')
-
-    def get_directions_as_html(self):
-        """returns the opening hours as html
-        """
-        return str(self.context.getDirections()).replace('\n', '<br />')
-
     def address(self):
         return self.address_ptl()
 

--- a/ftw/contentpage/content/addressblock.py
+++ b/ftw/contentpage/content/addressblock.py
@@ -21,6 +21,7 @@ if HAS_LINGUA_PLONE:
 else:
     from Products.Archetypes import atapi
 
+
 schema = atapi.Schema((
     atapi.BooleanField(
         'showTitle',
@@ -128,25 +129,34 @@ schema = atapi.Schema((
     atapi.TextField(
         name='openingHours',
         schemata='default',
-        default_output_type='text/html',
-        allowable_content_types=('text/plain',),
-        widget=atapi.TextAreaWidget(
+        default_input_type='text/html',
+        default_output_type='text/x-html-safe',
+        allowable_content_types=('text/html', ),
+        default_content_type='text/html',
+        validators=('isTidyHtmlWithCleanup', ),
+        widget=atapi.RichWidget(
             label=_(u'label_openingHours',
                     default=u'Opening Hours'),
             description=_(u'help_openingHours',
-                          default=u''))),
+                          default=u''),
+            allow_file_upload=False,
+            rows=10)),
 
     atapi.TextField(
         name='directions',
         schemata='default',
-        default_output_type='text/html',
-        allowable_content_types=('text/plain',),
-        widget=atapi.TextAreaWidget(
+        allowable_content_types=('text/html', ),
+        default_content_type='text/html',
+        validators=('isTidyHtmlWithCleanup', ),
+        default_input_type='text/html',
+        default_output_type='text/x-html-safe',
+        widget=atapi.RichWidget(
             label=_(u'label_directions',
                     default=u'Directions'),
             description=_(u'help_directions',
-                          default=u''))),
-
+                          default=u''),
+            allow_file_upload=False,
+            rows=10)),
 ))
 
 
@@ -154,6 +164,11 @@ addressblock_schema = ATContentTypeSchema.copy() + schema.copy()
 
 addressblock_schema['title'].required = False
 addressblock_schema['title'].default_method = 'getDefaultTitle'
+
+allowed_buttons = ('bold', 'link', 'unlink', 'anchor')
+
+addressblock_schema['directions'].widget.allow_buttons = allowed_buttons
+addressblock_schema['openingHours'].widget.allow_buttons = allowed_buttons
 
 # Finalize schema
 finalize(addressblock_schema, hide=['description'])

--- a/ftw/contentpage/profiles/default/metadata.xml
+++ b/ftw/contentpage/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>1602</version>
+    <version>1603</version>
     <dependencies>
         <dependency>profile-simplelayout.base:default</dependency>
         <dependency>profile-simplelayout.portlet.dropzone:default</dependency>

--- a/ftw/contentpage/tests/test_addressblockview.py
+++ b/ftw/contentpage/tests/test_addressblockview.py
@@ -6,8 +6,6 @@ from simplelayout.base.interfaces import ISimpleLayoutCapable
 from ftw.contentpage.interfaces import IFtwContentPageLayer
 from mocker import ANY
 
-OPENING_HOURS = DIRECTTIONS = "Line1\nLine2\nLine3"
-
 
 class TestAddressBlockView(MockTestCase):
 
@@ -19,8 +17,6 @@ class TestAddressBlockView(MockTestCase):
         self.request = self.stub_request(IFtwContentPageLayer)
         self.context = self.providing_stub(IAddressBlock)
         self.expect(self.context.getAddress()).result("Address line")
-        self.expect(self.context.getOpeningHours()).result(OPENING_HOURS)
-        self.expect(self.context.getDirections()).result(DIRECTTIONS)
         self.expect(self.context.getExtraAddressLine()).result(
             "Additional line")
 
@@ -48,20 +44,6 @@ class TestAddressBlockView(MockTestCase):
                                name="block_view")
         self.assertEquals(view.get_address_as_html(),
                           "Address line<br />Additional line")
-
-    def test_get_opening_hours_as_html(self):
-        self.replay()
-        view = getMultiAdapter((self.context, self.request),
-                               name="block_view")
-        self.assertEquals(view.get_opening_hours_as_html(),
-                          "Line1<br />Line2<br />Line3")
-
-    def test_get_directions_as_html(self):
-        self.replay()
-        view = getMultiAdapter((self.context, self.request),
-                               name="block_view")
-        self.assertEquals(view.get_directions_as_html(),
-                          "Line1<br />Line2<br />Line3")
 
     def test_has_team(self):
         parent = self.providing_stub(ISimpleLayoutCapable)

--- a/ftw/contentpage/upgrades/configure.zcml
+++ b/ftw/contentpage/upgrades/configure.zcml
@@ -356,4 +356,14 @@
         directory="profiles/1602"
         />
 
+    <!-- 1602 -> 1603 -->
+    <genericsetup:upgradeStep
+        title="Convert addressblock opening hours and directions to html"
+        description=""
+        source="1602"
+        destination="1603"
+        handler="ftw.contentpage.upgrades.to1601.ConvertAddressblockToHTML"
+        profile="ftw.contentpage:default"
+        />
+
 </configure>

--- a/ftw/contentpage/upgrades/to1601.py
+++ b/ftw/contentpage/upgrades/to1601.py
@@ -1,0 +1,27 @@
+from ftw.contentpage.interfaces import IAddressBlock
+from ftw.upgrade import UpgradeStep
+from Products.CMFCore.utils import getToolByName
+
+
+class ConvertAddressblockToHTML(UpgradeStep):
+
+    def __call__(self):
+        portal_transforms = getToolByName(self, 'portal_transforms')
+
+        query = {'object_provides': IAddressBlock.__identifier__}
+        for obj in self.catalog_unrestricted_search(query, full_objects=True):
+            if obj.directions.getContentType() == 'text/plain':
+                directions = portal_transforms.convertTo(
+                    'text/html',
+                    obj.getRawDirections(),
+                    mimetype='text/plain').getData()
+                directions = directions.replace('\r', '')
+                obj.setDirections(directions)
+
+            if obj.openingHours.getContentType() == 'text/plain':
+                openingHours = portal_transforms.convertTo(
+                    'text/html',
+                    obj.getRawOpeningHours(),
+                    mimetype='text/plain').getData()
+                openingHours = openingHours.replace('\r', '')
+                obj.setOpeningHours(openingHours)


### PR DESCRIPTION
- Changed `directions` and `openingHours` on `Addressblock` from `text/plain` to `text/html` fields.
- Activated tinyMCE widget for those fields.
  - Restricted buttons to bold and link buttons.
- Added upgrade step to convert changed fields on existing `Addressblock` objects to new ContentType.
- Removed `get_opening_hours_as_html` and `get_directions_as_html` and corresponding tests. The new widget saves the input as html, so no conversion is necessary.

@maethu 
