### PR TITLE
Improved news portlet title.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Display the user defined title of the news portlet instance in the
+  "manage portlets" screen.
+  [mbaechtold]
 
 
 1.8.1 (2014-10-20)

--- a/ftw/contentpage/portlets/news_portlet.py
+++ b/ftw/contentpage/portlets/news_portlet.py
@@ -194,7 +194,12 @@ class Assignment(base.Assignment):
 
     @property
     def title(self):
-        return u'News Portlet'
+        """This property is used to display the title of the portlet in the
+        "manage portlets" screen. The user defined title of the portlet
+        instance is appended to the default title which is useful if there
+        is more than one news portlet.
+        """
+        return u'News Portlet ({0})'.format(self.portlet_title)
 
 
 class Renderer(base.Renderer):


### PR DESCRIPTION
Display the user defined title of the news portlet instance in the "manage portlets" screen which is useful if there is more than one news portlet.
