### PR TITLE
Fixed styling for jquery.colorbox.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.8.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Changed styling for colorbox. Title and description on one line.
+  [Bieri Kevin]
 
 
 1.8.4 (2014-12-02)

--- a/ftw/contentpage/browser/resources/contentpage.css
+++ b/ftw/contentpage/browser/resources/contentpage.css
@@ -129,7 +129,16 @@ div.eventData {
   padding-left: 0.5em;
   background: #FFF;
   background: rgba(255, 255, 255, 0.8);
-  width: auto;
+  width: 100%;
+  bottom: 20px;
+  padding: 0.5em;
+  box-sizing: border-box;
+  text-align: left;
+}
+
+#cboxTitle b{
+  display: inline-block;
+  width: 100%;
 }
 
 


### PR DESCRIPTION
![bildschirmfoto 2014-12-02 um 10 52 30](https://cloud.githubusercontent.com/assets/1637820/5260647/732fa96a-7a11-11e4-8d5b-69fee5fb49a3.png)

New styling for colorbox in listingblock.
