### PR TITLE
Fix a bug preventing the listing of news.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,10 @@ Changelog
   Summary on table is no longer valid for accessiblity.
   [Kevin Bieri]
 
+- Bugfix: render the news on the newslisting view when the news portlet
+  is inherited from an ancestor.
+  [mbaechtold]
+
 
 1.8.6 (2014-12-11)
 ------------------

--- a/ftw/contentpage/browser/newslisting.py
+++ b/ftw/contentpage/browser/newslisting.py
@@ -69,6 +69,18 @@ class NewsPortletListing(NewsListing):
         if not manager_name or not name:
             return
 
+        managers_and_assignments = self.get_manager_and_assignments(
+            manager_name
+        )
+        for manager, assignments in managers_and_assignments:
+            if name in assignments:
+                return queryMultiAdapter(
+                    (self.context, self.request, self,
+                     manager, assignments[name]),
+                    IPortletRenderer)
+        return
+
+    def get_manager_and_assignments(self, manager_name):
         context = self.context
 
         # Prepare a list of objects by walking up the path.
@@ -92,14 +104,7 @@ class NewsPortletListing(NewsListing):
             if assignments is not None:
                 managers_and_assignments.append((manager, assignments))
 
-        # Finally get the portlet.
-        for manager, assignments in managers_and_assignments:
-            if name in assignments:
-                return queryMultiAdapter(
-                    (context, self.request, self,
-                     manager, assignments[name]),
-                    IPortletRenderer)
-        return
+        return managers_and_assignments
 
     def get_items(self):
         portlet = self.get_portlet()

--- a/ftw/contentpage/browser/newslisting.py
+++ b/ftw/contentpage/browser/newslisting.py
@@ -74,10 +74,7 @@ class NewsPortletListing(NewsListing):
         # Prepare a list of objects by walking up the path.
         contexts = [context]
         while not IPloneSiteRoot.providedBy(context):
-            if IAcquirer.providedBy(context):
-                context = aq_parent(aq_inner(context))
-            else:
-                context = context.__parent__
+            context = aq_parent(aq_inner(context))
             contexts.append(context)
 
         # Prepare a list of tuples in the form `(manager, assignments)`.
@@ -96,9 +93,7 @@ class NewsPortletListing(NewsListing):
                 managers_and_assignments.append((manager, assignments))
 
         # Finally get the portlet.
-        for item in managers_and_assignments:
-            manager = item[0]
-            assignments = item[1]
+        for manager, assignments in managers_and_assignments:
             if name in assignments:
                 return queryMultiAdapter(
                     (context, self.request, self,

--- a/ftw/contentpage/tests/test_newsportlet_listing.py
+++ b/ftw/contentpage/tests/test_newsportlet_listing.py
@@ -1,14 +1,10 @@
 from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.contentpage.portlets import news_portlet
-from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
 from ftw.testbrowser import browsing
-from plone.portlets.interfaces import IPortletAssignmentMapping
-from plone.portlets.interfaces import IPortletManager
 from unittest2 import TestCase
-from zope.component import getMultiAdapter
-from zope.component import getUtility
+
+from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
 
 
 class TestNewsPortletListing(TestCase):
@@ -68,12 +64,13 @@ class TestNewsPortletListing(TestCase):
     def test_newslisting_of_inherited_news_portlet(self, browser):
         # Create a news portlet on root which will be inherited by the root's
         # child objects.
-        manager = getUtility(IPortletManager, name='plone.rightcolumn')
-        assignments = getMultiAdapter((self.portal, manager),
-                                      IPortletAssignmentMapping)
-        assignments['news-portlet'] = news_portlet.Assignment(
-            portlet_title='Aktuell', quantity=5, days=10, more_news_link=True
-        )
+        create(Builder('news portlet')
+               .in_manager(u'plone.rightcolumn')
+               .within(self.portal)
+               .having(portlet_title='Aktuell',
+                       more_news_link=True,
+                       quantity=5,
+                       days=10))
 
         # Create a content page having a news folder. Create an old news
         # entry in the news folder.
@@ -97,5 +94,3 @@ class TestNewsPortletListing(TestCase):
         browser.find('More News').click()
         self.assertEquals(['Bookings open'],
                           browser.css('h2.tileHeadline').text)
-
-


### PR DESCRIPTION
This fixes the case where the news entries would not be rendered on
the newslisting view when the news portlet was inherited from an ancestor.