### PR TITLE
Remove empty paragraph tags from address block.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,6 +15,9 @@ Changelog
 - Fixed a bug during the rendering of the captcha on the feedback form.
   [mbaechtold]
 
+- Remove empty paragraph tags from address block.
+  [mbaechtold]
+
 
 1.8.6 (2014-12-11)
 ------------------

--- a/ftw/contentpage/profiles/default/metadata.xml
+++ b/ftw/contentpage/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>1605</version>
+    <version>1606</version>
     <dependencies>
         <dependency>profile-simplelayout.base:default</dependency>
         <dependency>profile-simplelayout.portlet.dropzone:default</dependency>

--- a/ftw/contentpage/upgrades/configure.zcml
+++ b/ftw/contentpage/upgrades/configure.zcml
@@ -385,4 +385,14 @@
         profile="ftw.contentpage:default"
         />
 
+    <!-- 1605 -> 1606 -->
+    <genericsetup:upgradeStep
+        title="Remove empty paragraph tags in address blocks."
+        description=""
+        source="1605"
+        destination="1606"
+        handler="ftw.contentpage.upgrades.to1606.RemoveEmptyParagraphTagsInAddressBlocks"
+        profile="ftw.contentpage:default"
+        />
+
 </configure>

--- a/ftw/contentpage/upgrades/to1606.py
+++ b/ftw/contentpage/upgrades/to1606.py
@@ -1,0 +1,13 @@
+from ftw.contentpage.interfaces import IAddressBlock
+from ftw.upgrade import UpgradeStep
+
+
+class RemoveEmptyParagraphTagsInAddressBlocks(UpgradeStep):
+
+    def __call__(self):
+        query = {'object_provides': IAddressBlock.__identifier__}
+        for obj in self.catalog_unrestricted_search(query, full_objects=True):
+            if obj.getRawDirections() == '<p></p>':
+                obj.setDirections('')
+            if obj.getRawOpeningHours() == '<p></p>':
+                obj.setOpeningHours('')


### PR DESCRIPTION
An older upgrade step converted empty directions and opening hours
of address blocks to an empty paragraphs causing the heading of
the directions to be displayed even if there are no directions
available.