### PR TITLE
Render custom title and description of news listing.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Render the title of the portlet on the news listing view and hide the
+  generic description.
+  [mbaechtold]
 
 
 1.9.0 (2015-01-09)

--- a/ftw/contentpage/browser/newslisting.pt
+++ b/ftw/contentpage/browser/newslisting.pt
@@ -16,6 +16,16 @@
     </style>
 </metal:slot>
 
+<metal:title fill-slot="content-title">
+    <h1 class="documentFirstHeading" tal:content="view/title"></h1>
+</metal:title>
+
+<metal:description fill-slot="content-description">
+     <metal:comment tal:content="nothing">
+         No description
+     </metal:comment>
+ </metal:description>
+
 <metal:main fill-slot="content-core">
 
 <div i18n:domain="ftw.contentpage"

--- a/ftw/contentpage/browser/newslisting.py
+++ b/ftw/contentpage/browser/newslisting.py
@@ -112,3 +112,9 @@ class NewsPortletListing(NewsListing):
             return portlet.get_news(all_news=True)
 
         return []
+
+    def title(self):
+        portlet = self.get_portlet()
+        if portlet:
+            return portlet.data.portlet_title
+        return super(NewsPortletListing, self).title()

--- a/ftw/contentpage/tests/test_newsportlet_listing.py
+++ b/ftw/contentpage/tests/test_newsportlet_listing.py
@@ -94,3 +94,53 @@ class TestNewsPortletListing(TestCase):
         browser.find('More News').click()
         self.assertEquals(['Bookings open'],
                           browser.css('h2.tileHeadline').text)
+
+    @browsing
+    def test_newslisting_title(self, browser):
+        """
+        This test makes sure that the news listing view renders the
+        title of the portlet, not the generic title.
+        """
+        folder = create(Builder('news folder').titled('News'))
+        create(Builder('news').titled('Bookings open').within(folder))
+
+        create(Builder('news portlet')
+               .in_manager(u'plone.rightcolumn')
+               .having(portlet_title='Breaking News',
+                       only_context=False,
+                       path=['/{0}'.format(folder.getId())],
+                       more_news_link=True))
+
+        browser.login().open()
+        browser.find('More News').click()
+        self.assertEquals(
+            ['Breaking News'],
+            browser.css('h1.documentFirstHeading').text
+        )
+
+    @browsing
+    def test_newslisting_no_description(self, browser):
+        """
+        This test makes sure that the news listing view does not
+        render the generic description.
+        """
+        content_page = create(Builder('content page')
+                              .titled('My Page')
+                              .having(description='My Description'))
+
+        folder = create(Builder('news folder').titled('News'))
+        create(Builder('news').titled('Bookings open').within(folder))
+
+        create(Builder('news portlet')
+               .within(content_page)
+               .in_manager(u'plone.rightcolumn')
+               .having(only_context=False,
+                       path=['/{0}'.format(folder.getId())],
+                       more_news_link=True))
+
+        browser.login().visit(content_page)
+        browser.find('More News').click()
+        self.assertEquals(
+            0,
+            len(browser.css('div.documentDescription'))
+        )


### PR DESCRIPTION
Render the title of the portlet on the news listing view instead of the generic title. Hide the description because the portlet does not have one.