### PR TITLE
Upgrade news portlets: add always_render_portlet default value to assignments

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.9.1 (unreleased)
 ------------------
 
+- Upgrade news portlets: add always_render_portlet default value to assignments.
+  [jone]
+
 - Render the title of the portlet on the news listing view and hide the
   generic description.
   [mbaechtold]

--- a/ftw/contentpage/profiles/default/metadata.xml
+++ b/ftw/contentpage/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>1606</version>
+    <version>1607</version>
     <dependencies>
         <dependency>profile-simplelayout.base:default</dependency>
         <dependency>profile-simplelayout.portlet.dropzone:default</dependency>

--- a/ftw/contentpage/upgrades/configure.zcml
+++ b/ftw/contentpage/upgrades/configure.zcml
@@ -395,4 +395,14 @@
         profile="ftw.contentpage:default"
         />
 
+    <!-- 1606 -> 1607 -->
+    <genericsetup:upgradeStep
+        title="News portlet: set always_render_portlet attribute."
+        description=""
+        source="1606"
+        destination="1607"
+        handler="ftw.contentpage.upgrades.to1607.UpgradeNewsPortlet"
+        profile="ftw.contentpage:default"
+        />
+
 </configure>

--- a/ftw/contentpage/upgrades/to1607.py
+++ b/ftw/contentpage/upgrades/to1607.py
@@ -1,0 +1,35 @@
+from ftw.contentpage.portlets import news_portlet
+from ftw.upgrade import UpgradeStep
+from plone.portlets.interfaces import IPortletAssignmentMapping
+from plone.portlets.interfaces import IPortletManager
+from zope.component import getMultiAdapter
+from zope.component import getUtility
+
+
+class UpgradeNewsPortlet(UpgradeStep):
+    """Upgrade news portlets: add always_render_portlet default value to assignments.
+
+    When news portlets were added to the Plone site before ftw.contentpage 1.9.0,
+    the assignment has no always_render_portlet attribute.
+    When exporting portlets with Generic Setup, the Plone site assignments are
+    exported. If the attribute is missing, an AttributeError is raised.
+    """
+
+    def __call__(self):
+        for assignment in self.news_portlet_assignments_for(self.portal):
+            assignment.always_render_portlet = getattr(
+                assignment, 'always_render_portlet', False)
+
+    def news_portlet_assignments_for(self, context):
+        for assignment in self.get_assignments_for(self.portal):
+            if isinstance(assignment, news_portlet.Assignment):
+                yield assignment
+
+    def get_assignments_for(self, context):
+        for manager_name in ('plone.leftcolumn', 'plone.rightcolumn'):
+            manager = getUtility(IPortletManager, name=manager_name,
+                                 context=self.portal)
+            for assignment in getMultiAdapter((context, manager),
+                                              IPortletAssignmentMapping,
+                                              context=self.portal).values():
+                yield assignment


### PR DESCRIPTION
When news portlets were added to the Plone site before ftw.contentpage 1.9.0,
the assignment has no always_render_portlet attribute.
When exporting portlets with Generic Setup, the Plone site assignments are
exported. If the attribute is missing, an AttributeError is raised.

@mbaechtold 
//cc @maethu 