### PR TITLE
Extend IContentCategories behavior with a new field new content categories

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,6 @@ Changelog
 1.9.1 (unreleased)
 ------------------
 
-=======
 - Extend IContentCategories behavior with a new field "new content categories".
   [mathias.leimgruber]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,16 +4,20 @@ Changelog
 1.9.1 (unreleased)
 ------------------
 
+=======
+- Extend IContentCategories behavior with a new field "new content categories".
+  [mathias.leimgruber]
+
 - Don't limit the number of news entries when rendering all news.
   [mbaechtold]
-  
+
 - Render the news item's publication date on the RSS feed.
   [mbaechtold]
 
 - Fixed a bug which prevented whole day events from being listed on the
   event listing view.
   [mbaechtold]
-  
+
 - Fix cache decorator (from view to instance) for archive base portlet.
   If you have both archive portlets (news and event) on the same page
   the second archive portlet will use the result from the first one.

--- a/ftw/contentpage/behaviors/configure.zcml
+++ b/ftw/contentpage/behaviors/configure.zcml
@@ -4,16 +4,19 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="simplelayout">
 
-    <include package="plone.behavior" file="meta.zcml" />
-    <include package="plone.directives.form" file="meta.zcml" />
-    <include package="plone.directives.form" />
 
-    <plone:behavior
-        title="ftw.contentpage content categories behavior"
-        description="Extends a content by the content_categories field"
-        provides="ftw.contentpage.behaviors.content_categories.IContentCategories"
-        factory=".content_categories.ContentCategoriesStorage"
-        marker="ftw.contentpage.interfaces.ICategorizable"
-        />
+    <configure zcml:condition="have plone-43">
+      <include package="plone.behavior" file="meta.zcml" />
+      <include package="plone.directives.form" file="meta.zcml" />
+      <include package="plone.directives.form" />
+
+      <plone:behavior
+          title="ftw.contentpage content categories behavior"
+          description="Extends a content by the content_categories field"
+          provides="ftw.contentpage.behaviors.content_categories.IContentCategories"
+          factory=".content_categories.ContentCategoriesStorage"
+          marker="ftw.contentpage.interfaces.ICategorizable"
+          />
+  </configure>
 
 </configure>

--- a/ftw/contentpage/behaviors/configure.zcml
+++ b/ftw/contentpage/behaviors/configure.zcml
@@ -12,7 +12,7 @@
         title="ftw.contentpage content categories behavior"
         description="Extends a content by the content_categories field"
         provides="ftw.contentpage.behaviors.content_categories.IContentCategories"
-        factory="plone.behavior.AnnotationStorage"
+        factory=".content_categories.ContentCategoriesStorage"
         marker="ftw.contentpage.interfaces.ICategorizable"
         />
 

--- a/ftw/contentpage/behaviors/content_categories.py
+++ b/ftw/contentpage/behaviors/content_categories.py
@@ -1,5 +1,6 @@
 from ftw.contentpage import _
 from plone.autoform import directives
+from plone.autoform.directives import write_permission
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.behavior.annotation import AnnotationsFactoryImpl
 from plone.supermodel import model
@@ -23,6 +24,7 @@ class IContentCategories(model.Schema):
     )
     directives.widget('content_categories', CheckBoxFieldWidget)
 
+    write_permission(new_content_categories='ftw.contentpage.content_categories_behavior.add_new_categories')
     new_content_categories = schema.Tuple(
         title=_(u'label_new_categories', default=u'New categories'),
         description=_(u'help_new_categories',

--- a/ftw/contentpage/behaviors/content_categories.py
+++ b/ftw/contentpage/behaviors/content_categories.py
@@ -1,10 +1,14 @@
 from ftw.contentpage import _
-from plone.directives import form
+from plone.autoform import directives
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.behavior.annotation import AnnotationsFactoryImpl
+from plone.supermodel import model
+from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from zope import schema
 from zope.interface import alsoProvides
 
 
-class IContentCategories(form.Schema):
+class IContentCategories(model.Schema):
 
     """Content categories schema"""
 
@@ -12,10 +16,53 @@ class IContentCategories(form.Schema):
         title=_(u'label_categories', default=u'Categories'),
         description=_(u'help_categories',
                       default=u'Category for contentlisting'),
+        value_type=schema.Choice(title=_(u"categories"),
+                                 vocabulary='ftw.contentpage.contentcategories'),
+        required=False,
+        missing_value=(),
+    )
+    directives.widget('content_categories', CheckBoxFieldWidget)
+
+    new_content_categories = schema.Tuple(
+        title=_(u'label_new_categories', default=u'New categories'),
+        description=_(u'help_new_categories',
+                      default=u'New categories for contentlisting'),
         value_type=schema.TextLine(),
         required=False,
         missing_value=(),
     )
 
 
-alsoProvides(IContentCategories, form.IFormFieldProvider)
+alsoProvides(IContentCategories, IFormFieldProvider)
+
+
+class ContentCategoriesStorage(object):
+
+    def __init__(self, context):
+        self.context = context
+        self.annoation_storage = AnnotationsFactoryImpl(
+            self.context,
+            IContentCategories
+        )
+
+    @property
+    def content_categories(self):
+        return self.annoation_storage.content_categories
+
+    @content_categories.setter
+    def content_categories(self, value):
+        self.annoation_storage.content_categories = value
+
+    @property
+    def new_content_categories(self):
+        return ()
+
+    @new_content_categories.setter
+    def new_content_categories(self, value):
+        if value is None:
+            return ()
+        else:
+            categories = tuple(self.annoation_storage.content_categories)
+            self.annoation_storage.content_categories = tuple(set(
+                categories + value
+            ))

--- a/ftw/contentpage/config.py
+++ b/ftw/contentpage/config.py
@@ -1,3 +1,6 @@
+from pkg_resources import get_distribution
+
+
 PROJECTNAME = 'ftw.contentpage'
 
 
@@ -17,3 +20,10 @@ INDEXES = (('getContentCategories', 'KeywordIndex'),
 
 
 ORIGINAL_SIZE = (900, 900)
+
+
+
+if get_distribution('Plone').version >= '4.3':
+    HAS_CONTENT_LISTING_BEHAVIOR = True
+else:
+    HAS_CONTENT_LISTING_BEHAVIOR = False

--- a/ftw/contentpage/configure.zcml
+++ b/ftw/contentpage/configure.zcml
@@ -103,6 +103,11 @@
       name="ftw.contentpage.subjects"
     />
 
+    <utility
+      component=".vocabularies.contentcategories_vocabulary"
+      name="ftw.contentpage.contentcategories"
+    />
+
     <class class="ftw.contentpage.content.news.News">
           <implements interface="simplelayout.base.interfaces.ISimpleLayoutBlock" />
     </class>

--- a/ftw/contentpage/indexer.py
+++ b/ftw/contentpage/indexer.py
@@ -1,18 +1,22 @@
 from DateTime import DateTime
-from ftw.contentpage.behaviors.content_categories import IContentCategories
+from ftw.contentpage.config import HAS_CONTENT_LISTING_BEHAVIOR
 from ftw.contentpage.interfaces import ICategorizable, IEventPage
 from ftw.contentpage.interfaces import IContentPage
+from plone.dexterity.interfaces import IDexterityContent
 from plone.indexer.decorator import indexer
 from Products.Archetypes.interfaces import IBaseObject
 from simplelayout.base.interfaces import ISimpleLayoutBlock
-from plone.dexterity.interfaces import IDexterityContent
+
+
+if HAS_CONTENT_LISTING_BEHAVIOR:
+    from ftw.contentpage.behaviors.content_categories import IContentCategories
 
 
 @indexer(ICategorizable)
 def categories(obj, **kw):
     if IBaseObject.providedBy(obj):
         return obj.Schema()['content_categories'].get(obj)
-    elif IDexterityContent.providedBy(obj):
+    elif IDexterityContent.providedBy(obj) and HAS_CONTENT_LISTING_BEHAVIOR:
         return [item.encode('utf-8') for item in
                 IContentCategories(obj).content_categories]
     else:

--- a/ftw/contentpage/locales/de/LC_MESSAGES/ftw.contentpage.po
+++ b/ftw/contentpage/locales/de/LC_MESSAGES/ftw.contentpage.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-01-06 14:34+0000\n"
+"POT-Creation-Date: 2015-02-23 14:00+0000\n"
 "PO-Revision-Date: 2013-04-11 18:16+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -115,12 +115,12 @@ msgstr "Pfad"
 msgid "References"
 msgstr "Referenzen"
 
-#: ./ftw/contentpage/browser/feedback.py:77
+#: ./ftw/contentpage/browser/feedback.py:79
 msgid "Send Mail"
 msgstr "Senden"
 
 #. Default: "Name"
-#: ./ftw/contentpage/browser/feedback.py:35
+#: ./ftw/contentpage/browser/feedback.py:34
 msgid "Sender_Name"
 msgstr "Name"
 
@@ -131,7 +131,7 @@ msgstr "Schweiz"
 msgid "TextBlock"
 msgstr "Textblock"
 
-#: ./ftw/contentpage/browser/feedback.py:87
+#: ./ftw/contentpage/browser/feedback.py:89
 msgid "The captcha code you entered was wrong, please enter the new one."
 msgstr "Der eingegebene Captcha Code war falsch. Bitte geben sie den neuen Code ein."
 
@@ -158,9 +158,13 @@ msgid "View"
 msgstr "Anzeigen"
 
 #. Default: "Cancel"
-#: ./ftw/contentpage/browser/feedback.py:102
+#: ./ftw/contentpage/browser/feedback.py:104
 msgid "button_cancel"
 msgstr "Abbrechen"
+
+#: ./ftw/contentpage/behaviors/content_categories.py:28
+msgid "categories"
+msgstr "Kategorien"
 
 #. Default: "creater"
 #: ./ftw/contentpage/browser/listingblock_view.py:68
@@ -227,7 +231,7 @@ msgid "help_always_render_portlet"
 msgstr "Wenn diese Option aktiv ist, wird das Portlet auch angezeigt, wenn es gar keine News-Einträge gibt."
 
 #. Default: "Category for contentlisting"
-#: ./ftw/contentpage/behaviors/content_categories.py:13
+#: ./ftw/contentpage/behaviors/content_categories.py:26
 #: ./ftw/contentpage/extender.py:33
 msgid "help_categories"
 msgstr "Definieren Sie, unter welchen Rubrik diese Inhaltsseite abgelegt werden soll"
@@ -252,6 +256,11 @@ msgstr ""
 #: ./ftw/contentpage/extender.py:79
 msgid "help_mark_as_authority"
 msgstr "Dadurch werden Inhalte unter anderem Direkt auf der Behörden-Übersicht angezeigt."
+
+#. Default: "New categories for contentlisting"
+#: ./ftw/contentpage/behaviors/content_categories.py:37
+msgid "help_new_categories"
+msgstr "Eine Rubrik pro Zeile eingeben, mehrere Worte sind erlaubt."
 
 #: ./ftw/contentpage/portlets/news_portlet.py:44
 msgid "help_only_context"
@@ -293,7 +302,7 @@ msgid "help_www"
 msgstr "Geben Sie eine Internetadresse an (inkl. http://, https://, etc.)"
 
 #. Default: "The email was sent."
-#: ./ftw/contentpage/browser/feedback.py:98
+#: ./ftw/contentpage/browser/feedback.py:100
 msgid "info_email_sent"
 msgstr "E-Mail wurde versendet."
 
@@ -322,7 +331,7 @@ msgid "label_ascending"
 msgstr "Aufsteigend"
 
 #. Default: "by ${author}"
-#: ./ftw/contentpage/browser/newslisting.pt:41
+#: ./ftw/contentpage/browser/newslisting.pt:51
 msgid "label_by_author"
 msgstr "von ${author}"
 
@@ -332,7 +341,7 @@ msgid "label_cancel"
 msgstr "Abbrechen"
 
 #. Default: "Categories"
-#: ./ftw/contentpage/behaviors/content_categories.py:12
+#: ./ftw/contentpage/behaviors/content_categories.py:25
 #: ./ftw/contentpage/extender.py:32
 msgid "label_categories"
 msgstr "Rubrik"
@@ -406,7 +415,7 @@ msgid "label_fax"
 msgstr "Fax"
 
 #. Default: "${title} - News Feed"
-#: ./ftw/contentpage/browser/newslisting.py:57
+#: ./ftw/contentpage/browser/newslisting.py:59
 msgid "label_feed_desc"
 msgstr "${title} - News Feed"
 
@@ -442,7 +451,7 @@ msgid "label_mark_as_authority"
 msgstr "Inhalt als Organisation/Amt/Behörde/etc. markieren"
 
 #. Default: "Message"
-#: ./ftw/contentpage/browser/feedback.py:42
+#: ./ftw/contentpage/browser/feedback.py:41
 msgid "label_message"
 msgstr "Nachricht"
 
@@ -453,6 +462,11 @@ msgstr "Bearbeitungsdatum"
 #: ./ftw/contentpage/portlets/news_portlet.py:85
 msgid "label_more_news_link"
 msgstr "Link auf ältere Meldung darstellen"
+
+#. Default: " New categories"
+#: ./ftw/contentpage/behaviors/content_categories.py:36
+msgid "label_new_categories"
+msgstr "Neue Rubrik anlegen und benutzen."
 
 #: ./ftw/contentpage/portlets/news_portlet.py:43
 msgid "label_only_context"
@@ -499,7 +513,7 @@ msgid "label_save"
 msgstr "Speichern"
 
 #. Default: "Send Feedback"
-#: ./ftw/contentpage/browser/feedback.py:49
+#: ./ftw/contentpage/browser/feedback.py:48
 msgid "label_send_feedback"
 msgstr "Kontaktformular"
 
@@ -538,7 +552,7 @@ msgid "label_sortable_title"
 msgstr "Titel"
 
 #. Default: "Subject"
-#: ./ftw/contentpage/browser/feedback.py:40
+#: ./ftw/contentpage/browser/feedback.py:39
 msgid "label_subject"
 msgstr "Betreff"
 
@@ -572,7 +586,7 @@ msgid "label_zip"
 msgstr "PLZ"
 
 #. Default: "E-Mail"
-#: ./ftw/contentpage/browser/feedback.py:37
+#: ./ftw/contentpage/browser/feedback.py:36
 msgid "mail_address"
 msgstr "E-Mail"
 
@@ -587,7 +601,7 @@ msgid "no_recent_news_label"
 msgstr "Keine aktuellen Meldungen vorhanden."
 
 #. Default: "Read More…"
-#: ./ftw/contentpage/browser/newslisting.pt:59
+#: ./ftw/contentpage/browser/newslisting.pt:69
 msgid "read_more"
 msgstr "Weiterlesen..."
 
@@ -618,7 +632,7 @@ msgstr "Fax ${num}"
 
 #. Default: "No Contents"
 #: ./ftw/contentpage/browser/eventlisting.pt:51
-#: ./ftw/contentpage/browser/newslisting.pt:65
+#: ./ftw/contentpage/browser/newslisting.pt:75
 msgid "text_not_content"
 msgstr "Keine Inhalte"
 

--- a/ftw/contentpage/locales/fr/LC_MESSAGES/ftw.contentpage.po
+++ b/ftw/contentpage/locales/fr/LC_MESSAGES/ftw.contentpage.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-01-06 14:34+0000\n"
+"POT-Creation-Date: 2015-02-23 14:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -115,12 +115,12 @@ msgstr ""
 msgid "References"
 msgstr ""
 
-#: ./ftw/contentpage/browser/feedback.py:77
+#: ./ftw/contentpage/browser/feedback.py:79
 msgid "Send Mail"
 msgstr ""
 
 #. Default: "Name"
-#: ./ftw/contentpage/browser/feedback.py:35
+#: ./ftw/contentpage/browser/feedback.py:34
 msgid "Sender_Name"
 msgstr ""
 
@@ -131,7 +131,7 @@ msgstr ""
 msgid "TextBlock"
 msgstr ""
 
-#: ./ftw/contentpage/browser/feedback.py:87
+#: ./ftw/contentpage/browser/feedback.py:89
 msgid "The captcha code you entered was wrong, please enter the new one."
 msgstr "Le code captcha entré avait tort, se il vous plaît entrer le nouveau."
 
@@ -158,9 +158,13 @@ msgid "View"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./ftw/contentpage/browser/feedback.py:102
+#: ./ftw/contentpage/browser/feedback.py:104
 msgid "button_cancel"
 msgstr "Annuler"
+
+#: ./ftw/contentpage/behaviors/content_categories.py:28
+msgid "categories"
+msgstr "Catégories"
 
 #. Default: "creater"
 #: ./ftw/contentpage/browser/listingblock_view.py:68
@@ -227,7 +231,7 @@ msgid "help_always_render_portlet"
 msgstr "Lorsque cette option est activée, le portlet s'affiche même s'il n'y a pas de nouvelles."
 
 #. Default: "Category for contentlisting"
-#: ./ftw/contentpage/behaviors/content_categories.py:13
+#: ./ftw/contentpage/behaviors/content_categories.py:26
 #: ./ftw/contentpage/extender.py:33
 msgid "help_categories"
 msgstr ""
@@ -252,6 +256,11 @@ msgstr ""
 #: ./ftw/contentpage/extender.py:79
 msgid "help_mark_as_authority"
 msgstr ""
+
+#. Default: "New categories for contentlisting"
+#: ./ftw/contentpage/behaviors/content_categories.py:37
+msgid "help_new_categories"
+msgstr "Une catégorie par ligne, plusieurs mots sont permis."
 
 #: ./ftw/contentpage/portlets/news_portlet.py:44
 msgid "help_only_context"
@@ -293,7 +302,7 @@ msgid "help_www"
 msgstr ""
 
 #. Default: "The email was sent."
-#: ./ftw/contentpage/browser/feedback.py:98
+#: ./ftw/contentpage/browser/feedback.py:100
 msgid "info_email_sent"
 msgstr "Le courriel a été envoyé."
 
@@ -322,7 +331,7 @@ msgid "label_ascending"
 msgstr "Ascendant"
 
 #. Default: "by ${author}"
-#: ./ftw/contentpage/browser/newslisting.pt:41
+#: ./ftw/contentpage/browser/newslisting.pt:51
 msgid "label_by_author"
 msgstr "de ${author}"
 
@@ -332,7 +341,7 @@ msgid "label_cancel"
 msgstr "Annuler"
 
 #. Default: "Categories"
-#: ./ftw/contentpage/behaviors/content_categories.py:12
+#: ./ftw/contentpage/behaviors/content_categories.py:25
 #: ./ftw/contentpage/extender.py:32
 msgid "label_categories"
 msgstr "Catégories"
@@ -406,7 +415,7 @@ msgid "label_fax"
 msgstr ""
 
 #. Default: "${title} - News Feed"
-#: ./ftw/contentpage/browser/newslisting.py:57
+#: ./ftw/contentpage/browser/newslisting.py:59
 msgid "label_feed_desc"
 msgstr ""
 
@@ -442,7 +451,7 @@ msgid "label_mark_as_authority"
 msgstr ""
 
 #. Default: "Message"
-#: ./ftw/contentpage/browser/feedback.py:42
+#: ./ftw/contentpage/browser/feedback.py:41
 msgid "label_message"
 msgstr ""
 
@@ -453,6 +462,11 @@ msgstr ""
 #: ./ftw/contentpage/portlets/news_portlet.py:85
 msgid "label_more_news_link"
 msgstr "Afficher plus de lien nouvelles"
+
+#. Default: " New categories"
+#: ./ftw/contentpage/behaviors/content_categories.py:36
+msgid "label_new_categories"
+msgstr "Créer et utiliser nouvelle catégories"
 
 #: ./ftw/contentpage/portlets/news_portlet.py:43
 msgid "label_only_context"
@@ -499,7 +513,7 @@ msgid "label_save"
 msgstr "Enregistrer"
 
 #. Default: "Send Feedback"
-#: ./ftw/contentpage/browser/feedback.py:49
+#: ./ftw/contentpage/browser/feedback.py:48
 msgid "label_send_feedback"
 msgstr "Envoyer un commentaire"
 
@@ -538,7 +552,7 @@ msgid "label_sortable_title"
 msgstr ""
 
 #. Default: "Subject"
-#: ./ftw/contentpage/browser/feedback.py:40
+#: ./ftw/contentpage/browser/feedback.py:39
 msgid "label_subject"
 msgstr "Sujet"
 
@@ -572,7 +586,7 @@ msgid "label_zip"
 msgstr ""
 
 #. Default: "E-Mail"
-#: ./ftw/contentpage/browser/feedback.py:37
+#: ./ftw/contentpage/browser/feedback.py:36
 msgid "mail_address"
 msgstr ""
 
@@ -588,7 +602,7 @@ msgid "no_recent_news_label"
 msgstr "Pas de nouvelles récentes disponibles."
 
 #. Default: "Read More…"
-#: ./ftw/contentpage/browser/newslisting.pt:59
+#: ./ftw/contentpage/browser/newslisting.pt:69
 msgid "read_more"
 msgstr "En savoir plus..."
 
@@ -619,7 +633,7 @@ msgstr ""
 
 #. Default: "No Contents"
 #: ./ftw/contentpage/browser/eventlisting.pt:51
-#: ./ftw/contentpage/browser/newslisting.pt:65
+#: ./ftw/contentpage/browser/newslisting.pt:75
 msgid "text_not_content"
 msgstr "Pas de contenu"
 

--- a/ftw/contentpage/locales/ftw.contentpage.pot
+++ b/ftw/contentpage/locales/ftw.contentpage.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-01-06 14:34+0000\n"
+"POT-Creation-Date: 2015-02-23 14:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -115,12 +115,12 @@ msgstr ""
 msgid "References"
 msgstr ""
 
-#: ./ftw/contentpage/browser/feedback.py:77
+#: ./ftw/contentpage/browser/feedback.py:79
 msgid "Send Mail"
 msgstr ""
 
 #. Default: "Name"
-#: ./ftw/contentpage/browser/feedback.py:35
+#: ./ftw/contentpage/browser/feedback.py:34
 msgid "Sender_Name"
 msgstr ""
 
@@ -131,7 +131,7 @@ msgstr ""
 msgid "TextBlock"
 msgstr ""
 
-#: ./ftw/contentpage/browser/feedback.py:87
+#: ./ftw/contentpage/browser/feedback.py:89
 msgid "The captcha code you entered was wrong, please enter the new one."
 msgstr ""
 
@@ -158,8 +158,12 @@ msgid "View"
 msgstr ""
 
 #. Default: "Cancel"
-#: ./ftw/contentpage/browser/feedback.py:102
+#: ./ftw/contentpage/browser/feedback.py:104
 msgid "button_cancel"
+msgstr ""
+
+#: ./ftw/contentpage/behaviors/content_categories.py:28
+msgid "categories"
 msgstr ""
 
 #. Default: "creater"
@@ -227,7 +231,7 @@ msgid "help_always_render_portlet"
 msgstr ""
 
 #. Default: "Category for contentlisting"
-#: ./ftw/contentpage/behaviors/content_categories.py:13
+#: ./ftw/contentpage/behaviors/content_categories.py:26
 #: ./ftw/contentpage/extender.py:33
 msgid "help_categories"
 msgstr ""
@@ -251,6 +255,11 @@ msgstr ""
 
 #: ./ftw/contentpage/extender.py:79
 msgid "help_mark_as_authority"
+msgstr ""
+
+#. Default: "New categories for contentlisting"
+#: ./ftw/contentpage/behaviors/content_categories.py:37
+msgid "help_new_categories"
 msgstr ""
 
 #: ./ftw/contentpage/portlets/news_portlet.py:44
@@ -293,7 +302,7 @@ msgid "help_www"
 msgstr ""
 
 #. Default: "The email was sent."
-#: ./ftw/contentpage/browser/feedback.py:98
+#: ./ftw/contentpage/browser/feedback.py:100
 msgid "info_email_sent"
 msgstr ""
 
@@ -322,7 +331,7 @@ msgid "label_ascending"
 msgstr ""
 
 #. Default: "by ${author}"
-#: ./ftw/contentpage/browser/newslisting.pt:41
+#: ./ftw/contentpage/browser/newslisting.pt:51
 msgid "label_by_author"
 msgstr ""
 
@@ -332,7 +341,7 @@ msgid "label_cancel"
 msgstr ""
 
 #. Default: "Categories"
-#: ./ftw/contentpage/behaviors/content_categories.py:12
+#: ./ftw/contentpage/behaviors/content_categories.py:25
 #: ./ftw/contentpage/extender.py:32
 msgid "label_categories"
 msgstr ""
@@ -406,7 +415,7 @@ msgid "label_fax"
 msgstr ""
 
 #. Default: "${title} - News Feed"
-#: ./ftw/contentpage/browser/newslisting.py:57
+#: ./ftw/contentpage/browser/newslisting.py:59
 msgid "label_feed_desc"
 msgstr ""
 
@@ -442,7 +451,7 @@ msgid "label_mark_as_authority"
 msgstr ""
 
 #. Default: "Message"
-#: ./ftw/contentpage/browser/feedback.py:42
+#: ./ftw/contentpage/browser/feedback.py:41
 msgid "label_message"
 msgstr ""
 
@@ -452,6 +461,11 @@ msgstr ""
 #. Default: "Show more news link"
 #: ./ftw/contentpage/portlets/news_portlet.py:85
 msgid "label_more_news_link"
+msgstr ""
+
+#. Default: " New categories"
+#: ./ftw/contentpage/behaviors/content_categories.py:36
+msgid "label_new_categories"
 msgstr ""
 
 #: ./ftw/contentpage/portlets/news_portlet.py:43
@@ -499,7 +513,7 @@ msgid "label_save"
 msgstr ""
 
 #. Default: "Send Feedback"
-#: ./ftw/contentpage/browser/feedback.py:49
+#: ./ftw/contentpage/browser/feedback.py:48
 msgid "label_send_feedback"
 msgstr ""
 
@@ -538,7 +552,7 @@ msgid "label_sortable_title"
 msgstr ""
 
 #. Default: "Subject"
-#: ./ftw/contentpage/browser/feedback.py:40
+#: ./ftw/contentpage/browser/feedback.py:39
 msgid "label_subject"
 msgstr ""
 
@@ -572,7 +586,7 @@ msgid "label_zip"
 msgstr ""
 
 #. Default: "E-Mail"
-#: ./ftw/contentpage/browser/feedback.py:37
+#: ./ftw/contentpage/browser/feedback.py:36
 msgid "mail_address"
 msgstr ""
 
@@ -587,7 +601,7 @@ msgid "no_recent_news_label"
 msgstr ""
 
 #. Default: "Read More…"
-#: ./ftw/contentpage/browser/newslisting.pt:59
+#: ./ftw/contentpage/browser/newslisting.pt:69
 msgid "read_more"
 msgstr ""
 
@@ -618,7 +632,7 @@ msgstr ""
 
 #. Default: "No Contents"
 #: ./ftw/contentpage/browser/eventlisting.pt:51
-#: ./ftw/contentpage/browser/newslisting.pt:65
+#: ./ftw/contentpage/browser/newslisting.pt:75
 msgid "text_not_content"
 msgstr ""
 

--- a/ftw/contentpage/permissions.zcml
+++ b/ftw/contentpage/permissions.zcml
@@ -24,4 +24,9 @@
         title="ftw.contentpage: Toggle IAuthority marker interface"
         />
 
+    <permission
+        id="ftw.contentpage.content_categories_behavior.add_new_categories"
+        title="ftw.contentpage: Add new categories 'content categories behavior'"
+        />
+
 </configure>

--- a/ftw/contentpage/profiles/default/metadata.xml
+++ b/ftw/contentpage/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>1608</version>
+    <version>1609</version>
     <dependencies>
         <dependency>profile-simplelayout.base:default</dependency>
         <dependency>profile-simplelayout.portlet.dropzone:default</dependency>

--- a/ftw/contentpage/profiles/default/rolemap.xml
+++ b/ftw/contentpage/profiles/default/rolemap.xml
@@ -58,5 +58,10 @@
       <role name="Manager"/>
     </permission>
 
+    <permission name="ftw.contentpage: Add new categories 'content categories behavior'"
+                acquire="True">
+      <role name="Manager"/>
+    </permission>
+
   </permissions>
 </rolemap>

--- a/ftw/contentpage/profiles/uninstall/rolemap.xml
+++ b/ftw/contentpage/profiles/uninstall/rolemap.xml
@@ -31,5 +31,9 @@
                 acquire="True">
     </permission>
 
+    <permission name="ftw.contentpage: Add new categories 'content categories behavior'"
+                acquire="True">
+    </permission>
+
   </permissions>
 </rolemap>

--- a/ftw/contentpage/tests/test_content_categorie_behavior.py
+++ b/ftw/contentpage/tests/test_content_categorie_behavior.py
@@ -88,3 +88,19 @@ class TestContentCategoriesBehavior(TestCase):
             ('WITH unicode \xc3\xa4',
                 [('Democontent', sampledxcontent.absolute_url(), '')]),
             viewlet.get_content())
+
+    def test_adding_new_category_using_the_new_categories_field(self):
+        page = create(Builder('content page'))
+        sampledxcontent = create(Builder('sample')
+                                 .titled('Democontent')
+                                 .within(page)
+                                 .having(new_content_categories=(u'WITH unicode \xe4', )))
+
+        viewlet = self._get_viewlet(page)[0]
+        self.assertTrue(viewlet.available())
+
+        self.assertIn(
+            ('WITH unicode \xc3\xa4',
+                [('Democontent', sampledxcontent.absolute_url(), '')]),
+            viewlet.get_content())
+

--- a/ftw/contentpage/tests/test_content_categorie_behavior.py
+++ b/ftw/contentpage/tests/test_content_categorie_behavior.py
@@ -4,10 +4,12 @@ from ftw.builder import registry
 from ftw.builder.dexterity import DexterityBuilder
 from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
 from ftw.testbrowser import browsing
+from pkg_resources import get_distribution
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.fti import DexterityFTI
 from Products.CMFCore.utils import getToolByName
 from simplelayout.base.views import SimpleLayoutView
+from unittest2 import skipUnless
 from unittest2 import TestCase
 from zope import schema
 from zope.component import queryMultiAdapter
@@ -30,6 +32,7 @@ class SampleBuilder(DexterityBuilder):
 registry.builder_registry.register('sample', SampleBuilder)
 
 
+@skipUnless(get_distribution('Plone').version >= '4.3', 'requires plone 4.3')
 class TestContentCategoriesBehavior(TestCase):
 
     layer = FTW_CONTENTPAGE_FUNCTIONAL_TESTING

--- a/ftw/contentpage/upgrades/configure.zcml
+++ b/ftw/contentpage/upgrades/configure.zcml
@@ -415,4 +415,14 @@
         profile="ftw.contentpage:default"
         />
 
+    <!-- 1608 -> 1609 -->
+    <upgrade-step:importProfile
+        title="Add new add cateories permission (content categories behavior)"
+        profile="ftw.contentpage:default"
+        source="1608"
+        destination="1609"
+        directory="profiles/1609"
+        />
+
+
 </configure>

--- a/ftw/contentpage/upgrades/profiles/1609/rolemap.xml
+++ b/ftw/contentpage/upgrades/profiles/1609/rolemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<rolemap>
+  <permissions>
+
+    <permission name="ftw.contentpage: Add new categories 'content categories behavior'"
+                acquire="True">
+      <role name="Manager"/>
+    </permission>
+
+  </permissions>
+</rolemap>

--- a/ftw/contentpage/viewlets/contentlisting.py
+++ b/ftw/contentpage/viewlets/contentlisting.py
@@ -1,10 +1,14 @@
-from ftw.contentpage.behaviors.content_categories import IContentCategories
+from ftw.contentpage.config import HAS_CONTENT_LISTING_BEHAVIOR
 from ftw.contentpage.interfaces import ISummaryListingEnabled
 from plone.app.layout.viewlets import ViewletBase
 from plone.dexterity.interfaces import IDexterityContent
 from plone.memoize import instance
 from Products.Archetypes.interfaces import IBaseObject
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+if HAS_CONTENT_LISTING_BEHAVIOR:
+    from ftw.contentpage.behaviors.content_categories import IContentCategories
 
 
 class ContentListingViewlet(ViewletBase):
@@ -33,7 +37,7 @@ class ContentListingViewlet(ViewletBase):
         for obj in contents:
             if IBaseObject.providedBy(obj):
                 categories = obj.Schema()['content_categories'].get(obj)
-            elif IDexterityContent.providedBy(obj):
+            elif IDexterityContent.providedBy(obj) and HAS_CONTENT_LISTING_BEHAVIOR:
                 categories = [item.encode('utf-8') for item in
                               IContentCategories(obj).content_categories]
 

--- a/ftw/contentpage/vocabularies.py
+++ b/ftw/contentpage/vocabularies.py
@@ -31,3 +31,16 @@ def SubjectVocabulary(context):
     return vocabulary.SimpleVocabulary(terms)
 
 directlyProvides(SubjectVocabulary, IVocabularyFactory)
+
+
+def contentcategories_vocabulary(context):
+    normalizer = queryUtility(IIDNormalizer)
+    catalog = getToolByName(context, 'portal_catalog')
+    terms = []
+    for term in catalog.uniqueValuesFor("getContentCategories"):
+        terms.append(SimpleTerm(value=term.decode('utf8'),
+                                token=normalizer.normalize(term.decode('utf8')),
+                                title=term.decode('utf8')))
+    return vocabulary.SimpleVocabulary(terms)
+
+directlyProvides(contentcategories_vocabulary, IVocabularyFactory)


### PR DESCRIPTION

- Add new content categories should work the same way in AT and DX.
- This PR adds a new field called `new content categories.`
- Implements it own behavior storage (new content categories gets stored in content categories).
- Should have no impact at all (indexing, etc.)
- Protect the new add content categories field with a permission

The new permission is not managed by lawgiver on purpose.
Because it should act like the RolesAllowedToAddNewKeyworts
global configuration on AT KeywordWidgets.