### PR TITLE
Fix encoding error in filename of textblock image when rendering.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix encoding error in filename of textblock image when rendering.
+  [jone]
 
 
 1.10.0 (2015-02-24)

--- a/ftw/contentpage/browser/textblock_view.py
+++ b/ftw/contentpage/browser/textblock_view.py
@@ -35,7 +35,8 @@ class TextBlockView(BrowserView):
                         self.context.getCharset())
 
         if not alt:
-            alt = self.context.getImage().filename
+            alt = unicode(self.context.getImage().filename or '',
+                          self.context.getCharset())
 
         image_util = getUtility(
             IScaleImage,

--- a/ftw/contentpage/tests/test_textblockview.py
+++ b/ftw/contentpage/tests/test_textblockview.py
@@ -140,6 +140,16 @@ class TestTextBlockView(TestCase):
         self.assertIn(view.image_wrapper_style(),
                       self.browser.contents)
 
+    def test_image_with_umlauts_in_filename(self):
+        textblock = self._create_textblock()
+        view = queryMultiAdapter((textblock, textblock.REQUEST),
+                                  name='block_view')
+
+        with open("%s/dummy.png" % os.path.split(__file__)[0], 'r') as dummy:
+            textblock.setImage(dummy)
+        textblock.getImage().filename = 'K\xc3\xbcche.png'
+        self.assertIn(u'K\xfcche.png', view.get_image_tag())
+
     def test_get_css_klass(self):
         textblock = self._create_textblock()
         view = queryMultiAdapter((textblock, textblock.REQUEST),


### PR DESCRIPTION
When the textblock image filename contains umlauts, rendering fails.