### PR TITLE
Fix a bug which prevented the successful rendering of the textblock.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 1.11.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed a bug which prevented the successful rendering of the textblock
+  when the image's alt text was based on a unicode string filename ("decoding
+  Unicode is not supported").
+  [mbaechtold]
 
 
 1.11.1 (2015-03-12)

--- a/ftw/contentpage/browser/textblock_view.py
+++ b/ftw/contentpage/browser/textblock_view.py
@@ -29,14 +29,16 @@ class TextBlockView(BrowserView):
         return bool(self.context.getImage())
 
     def get_image_tag(self):
-        alt = unicode(self.context.getImageAltText(),
-                      self.context.getCharset())
+        alt = self.context.getImageAltText()
         title = unicode(self.context.getImageCaption(),
                         self.context.getCharset())
 
         if not alt:
-            alt = unicode(self.context.getImage().filename or '',
-                          self.context.getCharset())
+            # Note: The file name might be a unicode string.
+            alt = self.context.getImage().filename or ''
+
+        if not isinstance(alt, unicode):
+            alt = unicode(alt, self.context.getCharset())
 
         image_util = getUtility(
             IScaleImage,


### PR DESCRIPTION
This was the case when the image's alt text was based on a unicode string filename ("decoding Unicode is not supported").