### PR TITLE
Fix teaser condition in textblock view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.11.2 (unreleased)
 -------------------
 
+- Fix a bug in the textblock view when subclassed textblock types have
+  no teaser block schema.
+  [jone]
+
 - Fixed a bug which prevented the successful rendering of the textblock
   when the image's alt text was based on a unicode string filename ("decoding
   Unicode is not supported").

--- a/ftw/contentpage/browser/textblock_view.py
+++ b/ftw/contentpage/browser/textblock_view.py
@@ -28,6 +28,11 @@ class TextBlockView(BrowserView):
             return False
         return bool(self.context.getImage())
 
+    def has_teaser(self):
+        """Returns True when the current context uses the teaser_schema.
+        """
+        return 'teaserSelectLink' in self.context.Schema()
+
     def get_image_tag(self):
         alt = self.context.getImageAltText()
         title = unicode(self.context.getImageCaption(),
@@ -74,6 +79,9 @@ class TextBlockView(BrowserView):
         return height and 'height: %spx' % height or ''
 
     def get_image_url(self):
+        if not self.has_teaser():
+            return None
+
         teaser_url = self.get_teaser_url()
         if teaser_url:
             return teaser_url
@@ -84,6 +92,9 @@ class TextBlockView(BrowserView):
         return None
 
     def get_teaser_url(self):
+        if not self.has_teaser():
+            return None
+
         linkSelector = self.context.getTeaserSelectLink()
 
         if linkSelector == 'intern':


### PR DESCRIPTION
Fix a bug in the textblock view when subclassed textblock types have no teaser block schema.

The current versions (`1.11.0`, `1.11.1`) are incompatible with [`ftw.book`s HTMLBlock](https://github.com/4teamwork/ftw.book/blob/master/ftw/book/content/htmlblock.py#L36), which subclasses the TextBlock, uses the same view, but does not use the teaser_schema.