### PR TITLE
Fixed bug where textblock title linked to image instead of teaser location.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.11.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed bug where textblock title linked to image instead of teaser location.
+  [lknoepfel]
 
 
 1.11.2 (2015-03-16)

--- a/ftw/contentpage/browser/textblock_view.pt
+++ b/ftw/contentpage/browser/textblock_view.pt
@@ -6,7 +6,7 @@
      tal:attributes="class string:simplelayout-block-wrapper TextBlock ${slclass}${fullblock};
                      style string:${view/get_block_height}">
         <a tal:attributes="id here/id" ></a>
-        <a tal:attributes="href view/get_image_url" tal:omit-tag="not: view/get_image_url">
+        <a tal:attributes="href view/get_teaser_url" tal:omit-tag="not: view/get_teaser_url">
             <h2 tal:content="here/Title" tal:condition="here/getShowTitle|python:True" />
         </a>
     <tal:IMAGE tal:condition="view/has_image">

--- a/ftw/contentpage/tests/test_textblock_teaser.py
+++ b/ftw/contentpage/tests/test_textblock_teaser.py
@@ -89,3 +89,25 @@ class TestTextblockTeaser(TestCase):
         self.assertEquals(
             linktarget,
             browser.css('.textblock .sl-img-wrapper a').first.attrib['href'])
+
+    @browsing
+    def test_teaser_link_on_title(self, browser):
+        linktarget = 'http://www.google.ch'
+
+        browser.open(self.contentpage)
+        self.assertEquals(
+            1,
+            len(browser.css('.TextBlock > a')),
+            "The title shouldn't be a link.")
+
+        self.textblock.setTeaserSelectLink('extern')
+        self.textblock.setTeaserExternalUrl(linktarget)
+        transaction.commit()
+
+        browser.open(self.contentpage)
+        self.assertEquals(
+            2,
+            len(browser.css('.TextBlock > a')),
+            "The title should link to the teaser target.")
+        self.assertEquals('http://www.google.ch',
+                          browser.css('.TextBlock > a')[1].attrib['href'])


### PR DESCRIPTION
Extranet: https://extranet.4teamwork.ch/support/zug/maintlog/10675

@jone 