### PR TITLE
Fix positioning of the external link icon next to the teaser title.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.11.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix position of external link icon when linking textblock titles
+  with the teaser feature.
+  [mbaechtold]
 
 
 1.11.3 (2015-04-14)

--- a/ftw/contentpage/browser/textblock_view.pt
+++ b/ftw/contentpage/browser/textblock_view.pt
@@ -5,10 +5,10 @@
                  fullblock python: text and ' sl-fullblock' or ''"
      tal:attributes="class string:simplelayout-block-wrapper TextBlock ${slclass}${fullblock};
                      style string:${view/get_block_height}">
-        <a tal:attributes="id here/id" ></a>
-        <a tal:attributes="href view/get_teaser_url" tal:omit-tag="not: view/get_teaser_url">
-            <h2 tal:content="here/Title" tal:condition="here/getShowTitle|python:True" />
-        </a>
+    <a tal:attributes="id here/id"></a>
+    <h2 tal:condition="here/getShowTitle|python:True">
+        <a tal:attributes="href view/get_teaser_url" tal:content="here/Title" tal:omit-tag="not: view/get_teaser_url"></a>
+    </h2>
     <tal:IMAGE tal:condition="view/has_image">
         <div class="sl-img-wrapper"
              tal:attributes="style view/image_wrapper_style"

--- a/ftw/contentpage/tests/test_textblock_teaser.py
+++ b/ftw/contentpage/tests/test_textblock_teaser.py
@@ -96,9 +96,9 @@ class TestTextblockTeaser(TestCase):
 
         browser.open(self.contentpage)
         self.assertEquals(
-            1,
-            len(browser.css('.TextBlock > a')),
-            "The title shouldn't be a link.")
+            0,
+            len(browser.css('div.TextBlock > h2 > a')),
+            "The title must not contain a link.")
 
         self.textblock.setTeaserSelectLink('extern')
         self.textblock.setTeaserExternalUrl(linktarget)
@@ -106,8 +106,12 @@ class TestTextblockTeaser(TestCase):
 
         browser.open(self.contentpage)
         self.assertEquals(
-            2,
-            len(browser.css('.TextBlock > a')),
-            "The title should link to the teaser target.")
-        self.assertEquals('http://www.google.ch',
-                          browser.css('.TextBlock > a')[1].attrib['href'])
+            1,
+            len(browser.css('div.TextBlock > h2 > a')),
+            "The title should link to the teaser target."
+            )
+
+        self.assertEquals(
+            'http://www.google.ch',
+            browser.css('.TextBlock > h2 > a').first.attrib['href'],
+            "The title must link to the teaser target.")


### PR DESCRIPTION
![teaser](https://cloud.githubusercontent.com/assets/28220/7567337/b305b91c-f7fc-11e4-8e77-84792e726a84.png)

/cc @shylux 