### PR TITLE
Add custom content page anchor view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.11.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Enable the selection of anchors from all the blocks of a content page in
+  the WYSIWYG editor (TinyMCE).
+  [mbaechtold, jone]
 
 
 1.11.3 (2015-04-14)

--- a/ftw/contentpage/__init__.py
+++ b/ftw/contentpage/__init__.py
@@ -1,3 +1,4 @@
+import logging
 from Products.Archetypes import atapi
 from Products.CMFCore import utils
 from ftw.contentpage import config
@@ -5,6 +6,14 @@ from zope.i18nmessageid import MessageFactory
 
 
 _ = MessageFactory('ftw.contentpage')
+
+logger = logging.getLogger('ftw.contentpage')
+
+# The following patch is a workaround for a bug in Products.TinyMCE < 1.4.0:
+# https://github.com/plone/Products.TinyMCE/commit/ccbe5ec5744680f73e4f64fa5d5bd00d37d51a80#comments
+logger.info('Patching TinyMCE anchor search pattern.')
+from Products.TinyMCE.browser import atanchors
+atanchors.SEARCHPATTERN = './/a'
 
 
 def initialize(context):

--- a/ftw/contentpage/browser/anchor.py
+++ b/ftw/contentpage/browser/anchor.py
@@ -1,0 +1,15 @@
+from Products.TinyMCE.browser.atanchors import ATAnchorView
+
+
+class ContentPageAnchorView(ATAnchorView):
+
+    def listAnchorNames(self, *args, **kwargs):
+        query = {'object_provides': 'simplelayout.base.interfaces.'
+                                    'ISimpleLayoutBlock'}
+
+        anchors = []
+        for block in self.context.listFolderContents(contentFilter=query):
+            view = block.restrictedTraverse('content_anchors')
+            anchors.extend(view.listAnchorNames(*args, **kwargs))
+
+        return anchors

--- a/ftw/contentpage/browser/configure.zcml
+++ b/ftw/contentpage/browser/configure.zcml
@@ -8,6 +8,14 @@
         name="ftw.contentpage.resources"
         directory="resources"
         />
+
+    <browser:view
+        name="content_anchors"
+        for="ftw.contentpage.interfaces.IContentPage"
+        class=".anchor.ContentPageAnchorView"
+        permission="zope2.View"
+        />
+
     <!-- AddressBlock views -->
     <browser:page
         for="ftw.contentpage.interfaces.IAddressBlock"

--- a/ftw/contentpage/content/textblock.py
+++ b/ftw/contentpage/content/textblock.py
@@ -32,6 +32,7 @@ default_schema = atapi.Schema((
 
     atapi.TextField(
         name='text',
+        primary=True,
         required=False,
         searchable=True,
         allowable_content_types=('text/html', ),

--- a/ftw/contentpage/tests/test_anchors.py
+++ b/ftw/contentpage/tests/test_anchors.py
@@ -1,0 +1,31 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
+from ftw.testbrowser import browsing
+from unittest2 import TestCase
+
+
+class TestAnchors(TestCase):
+
+    layer = FTW_CONTENTPAGE_FUNCTIONAL_TESTING
+
+    @browsing
+    def test_anchors(self, browser):
+        """
+        This test makes sure that `ContentPageAnchorView` is able
+        to extract the anchors form the text blocks of a content page.
+        """
+        contentpage = create(Builder('content page').titled('The Page'))
+        create(Builder('text block')
+               .within(contentpage)
+               .having(text="<p>Lorem <a name='anchor-textblock1'></a> "
+                            "ipsum dolor sit amet.</p>"))
+        create(Builder('text block')
+               .within(contentpage)
+               .having(text="<p>Lorem <a name='anchor-textblock2'></a> "
+                            "ipsum dolor sit amet.</p>"))
+
+        view = contentpage.restrictedTraverse('content_anchors')
+        anchor_names = view.listAnchorNames()
+        self.assertEqual(['anchor-textblock1', 'anchor-textblock2'],
+                         anchor_names)


### PR DESCRIPTION
This view enables the user to insert links to any anchor of all the text blocks in a content page.