### PR TITLE
Revert the linking of the image caption of a textblock.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.11.5 (unreleased)
 -------------------
 
+- Revert the linking of the image title of a textblock accidentally introduced
+  in 1.11.0.
+  [mbaechtold]
+
 - Fix NewsPortlet creation - always_render_portlet was missing.
   [mathias.leimgruber]
 

--- a/ftw/contentpage/browser/textblock_view.pt
+++ b/ftw/contentpage/browser/textblock_view.pt
@@ -21,9 +21,9 @@
                                         tal:omit-tag="not: view/get_image_url | nothing"
                     >
                         <img tal:replace="structure view/get_image_tag" />
-                        <p tal:condition="image_desc"
-                           tal:content="context/getImageCaption">Caption</p>
                     </a>
+                    <p tal:condition="image_desc"
+                       tal:content="context/getImageCaption">Caption</p>
         </div>
     </tal:IMAGE>
     <div tal:condition="text" class="sl-text-wrapper">

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -6,3 +6,7 @@ extends =
 
 package-name = ftw.contentpage
 
+versions = versions
+
+[versions]
+mocker = 1.1.1


### PR DESCRIPTION
This has accidentally been introduced in 1.11.0 (git commit hash 08848cf4d581a4823d104eceb5c273ea566e0047).