### PR TITLE
use current time for effective date. 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.11.6 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Use current time instead of midnight for News effectivedate default.
+  [tschanzt]
 
 
 1.11.5 (2015-06-18)

--- a/ftw/contentpage/content/news.py
+++ b/ftw/contentpage/content/news.py
@@ -37,7 +37,7 @@ class News(contentpage.ContentPage):
     schema = news_schema
 
     def getDefaultEffectiveDate(self):
-        return DateTime().Date()
+        return DateTime()
 
 
 registerType(News, PROJECTNAME)

--- a/ftw/contentpage/tests/test_news_effective.py
+++ b/ftw/contentpage/tests/test_news_effective.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from ftw.builder import create
+from ftw.builder import Builder
+from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
+from pytz import timezone as tz
+from unittest2 import TestCase
+
+
+class TestNewsEffective(TestCase):
+
+    layer = FTW_CONTENTPAGE_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.newsfolder = create(Builder('news folder'))
+
+    def test_effective(self):
+        self.news = create(Builder('news').within(self.newsfolder))
+        difference = datetime.now(tz('Europe/Zurich')) -\
+            self.news.effective().asdatetime()
+        # The folllowing Calculation is the same as timedelta.total_seconds()
+        # but since it isn't available in python2.6 we need to calculate it ourself
+        # https://docs.python.org/2/library/datetime.html#datetime.timedelta.total_seconds
+        self.assertLess((difference.microseconds +
+                        (difference.seconds + difference.days * 24 * 3600)
+                        * 10 ** 6) / 10.0 ** 6, 60)


### PR DESCRIPTION
@maethu News now use current time as default instad of midnight.