### PR TITLE
Fix news portlet context when viewing a news item.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.11.7 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix news portlet context when viewing a news item.
+  [lknoepfel]
 
 
 1.11.6 (2015-09-02)

--- a/ftw/contentpage/portlets/news_portlet.py
+++ b/ftw/contentpage/portlets/news_portlet.py
@@ -1,6 +1,8 @@
 from Acquisition import aq_parent, aq_inner
 from DateTime import DateTime
 from ftw.contentpage import _
+from ftw.contentpage.interfaces import INews
+from ftw.contentpage.interfaces import INewsFolder
 from plone.app.portlets.browser.interfaces import IPortletAddForm
 from plone.app.portlets.browser.interfaces import IPortletEditForm
 from plone.app.portlets.interfaces import IPortletPermissionChecker
@@ -244,7 +246,7 @@ class Renderer(base.Renderer):
         query = {'object_provides': 'ftw.contentpage.interfaces.INews'}
 
         if self.data.only_context:
-            path = '/'.join(self.context.getPhysicalPath())
+            path = '/'.join(self.get_news_context().getPhysicalPath())
             query['path'] = {'query': path}
 
         else:
@@ -295,6 +297,14 @@ class Renderer(base.Renderer):
 
         return '/'.join((self.context.absolute_url(),
                          '@@news_portlet_listing?{0}'.format(params)))
+
+    def get_news_context(self):
+        """ If we are in a news entry we have to get a parent node as start for
+        our query. Else it would only display the current obj in the portlet.
+        """
+        if INews.providedBy(self.context):
+            return aq_parent(aq_inner(self.context))
+        return self.context
 
 
 class EditForm(form.EditForm):


### PR DESCRIPTION
When on a `News Item` the news portlet only displays the one news entry you are currently viewing. This is because it uses a catalog query with the current context as path. The same problem exists on the news listing view.

This fix changes the query path to the parent of the `News Item`. This will generally be the `News Folder`.