### PR TITLE
Respect colorbox image_size property for images opened in overlay.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.11.7 (unreleased)
 -------------------
 
+- Respect colorbox image_size property for images opened in overlay.
+  This also solves caching issues (new image url).
+  [mathias.leimgruber]
+
 - Restrict versions of some dependencies so they don't pull in Plone 5.
   [mbaechtold]
 

--- a/ftw/contentpage/browser/listingblock_gallery_view.pt
+++ b/ftw/contentpage/browser/listingblock_gallery_view.pt
@@ -13,7 +13,7 @@
                tal:attributes="style string:width:${width};;height:${height}">
             <a href="#"
                tal:attributes="title string: <b>${img/title_or_id}</b> ${img/Description};
-                               href img/absolute_url">
+                               href python: view.get_image_large_url(img)">
               <img tal:replace="structure img/@@images/image/listingblock_gallery" />
             </a>
           </div>

--- a/ftw/contentpage/browser/listingblock_gallery_view.py
+++ b/ftw/contentpage/browser/listingblock_gallery_view.py
@@ -1,5 +1,8 @@
-from Products.Five.browser import BrowserView
+from ftw.colorbox.interfaces import IColorboxSettings
 from plone.app.imaging.utils import getAllowedSizes
+from plone.registry.interfaces import IRegistry
+from Products.Five.browser import BrowserView
+from zope.component import getUtility
 
 
 class ListingBlockGalleryView(BrowserView):
@@ -19,3 +22,18 @@ class ListingBlockGalleryView(BrowserView):
         sizes = getAllowedSizes()
         # Fallback is a plone default scale -> mini
         return sizes.get('listingblock_gallery', 'mini')
+
+    def get_image_large_url(self, img):
+        img_url = img.absolute_url()
+
+        registry = getUtility(IRegistry)
+        colorbox_settings = registry.forInterface(IColorboxSettings)
+
+        if colorbox_settings.image_size:
+            scales = img.restrictedTraverse('@@images')
+            scaled = scales.scale('image', scale=colorbox_settings.image_size)
+
+            if scaled:
+                return scaled.url
+
+        return img_url

--- a/ftw/contentpage/tests/test_galleryblock_img_url.py
+++ b/ftw/contentpage/tests/test_galleryblock_img_url.py
@@ -1,0 +1,63 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.colorbox.interfaces import IColorboxSettings
+from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
+from ftw.testbrowser import browsing
+from plone.registry.interfaces import IRegistry
+from unittest2 import TestCase
+from zope.component import getUtility
+import transaction
+
+
+class TestListingBlockCreation(TestCase):
+
+    layer = FTW_CONTENTPAGE_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(TestListingBlockCreation, self).setUp()
+        self.portal = self.layer['portal']
+        self.portal_url = self.portal.portal_url()
+
+        registry = getUtility(IRegistry)
+        self.colorbox_settings = registry.forInterface(IColorboxSettings)
+
+        self.page = create(Builder('content page'))
+        self.listingblock = create(Builder('listing block').within(self.page))
+        self.image = create(Builder('image')
+                            .with_dummy_content()
+                            .within(self.listingblock))
+
+    @browsing
+    def test_use_scale_for_large_image(self, browser):
+        self.colorbox_settings.image_size = u'colorbox'
+        transaction.commit()
+
+        browser.login().visit(self.listingblock, view='block_view-gallery')
+        link = browser.css('.sl-img-wrapper a').first
+
+        self.assertEquals(self.get_scaled_img_url(), link.attrib['href'])
+
+    @browsing
+    def test_not_scale_defined_returns_origin_image(self, browser):
+        self.colorbox_settings.image_size = u''
+        transaction.commit()
+
+        browser.login().visit(self.listingblock, view='block_view-gallery')
+        link = browser.css('.sl-img-wrapper a').first
+
+        self.assertEquals(self.image.absolute_url(), link.attrib['href'])
+
+    @browsing
+    def test_broken_scale_returns_origin_image(self, browser):
+        self.colorbox_settings.image_size = u'inexisting'
+        transaction.commit()
+
+        browser.login().visit(self.listingblock, view='block_view-gallery')
+        link = browser.css('.sl-img-wrapper a').first
+
+        self.assertEquals(self.image.absolute_url(), link.attrib['href'])
+
+    def get_scaled_img_url(self):
+        scales = self.image.restrictedTraverse('@@images')
+        scaled = scales.scale('image', scale=self.colorbox_settings.image_size)
+        return scaled.url


### PR DESCRIPTION
This leads to a url like this. 

<img width="463" alt="screen shot 2015-12-14 at 10 22 25" src="https://cloud.githubusercontent.com/assets/437933/11777150/a3dd2664-a24c-11e5-85fb-5baf1f93e1c0.png">


- Not the possible 10MB image will be loaded.
- Not cached if the image changes (new url).