### PR TITLE
Do not show map on addressblock if no address is given.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.11.8 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Do not show map on addressblock if no address is given.
+  [elioschmutz]
 
 
 1.11.7 (2015-12-23)

--- a/ftw/contentpage/browser/addressblock_detail_view.pt
+++ b/ftw/contentpage/browser/addressblock_detail_view.pt
@@ -13,7 +13,7 @@
 
         <div tal:replace="structure provider:plone.abovecontentbody" />
         <div class="addressWrapper">
-          <div class="addressMap">
+          <div class="addressMap" tal:condition="view/show_map">
             <div id="kml-content-viewlet">
               <metal:use use-macro="context/@@collectivegeo-macros/openlayers" />
               <metal:use use-macro="context/@@collectivegeo-macros/map-widget" />

--- a/ftw/contentpage/browser/addressblock_view.pt
+++ b/ftw/contentpage/browser/addressblock_view.pt
@@ -6,7 +6,7 @@
     <div class="addressText">
       <div tal:replace="structure view/address">Address</div>
     </div>
-    <div class="addressMap">
+    <div class="addressMap" tal:condition="view/show_map">
       <div id="kml-content-viewlet">
         <tal:omit tal:define="cgmap view/get_address_map" tal:omit-tag="">
           <metal:use use-macro="context/@@collectivegeo-macros/map-widget" />

--- a/ftw/contentpage/browser/addressblock_view.py
+++ b/ftw/contentpage/browser/addressblock_view.py
@@ -1,4 +1,6 @@
-from Acquisition import aq_inner, aq_parent
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from collective.geo.geographer.interfaces import IGeoreferenced
 from collective.geo.mapwidget.browser.widget import MapWidget
 from ftw.contentpage.interfaces import IAddressBlockView
 from Products.Five.browser import BrowserView
@@ -27,6 +29,9 @@ class AddressBlockView(BrowserView):
         address_map.addClass('addressblock-map')
 
         return address_map
+
+    def show_map(self):
+        return IGeoreferenced(self.context).hasCoordinates()
 
 
 class AddressBlockPortletView(AddressBlockView):


### PR DESCRIPTION
The addressblock should not show the map if no address is given.

This PR removes the map if no address is given.