### PR TITLE
Rename several views and portletnames in favor of ftw.news.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-1.12.1 (unreleased)
+1.13.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Rename several views and portletnames in favor of ftw.news.
+  [mathias.leimgruber]
 
 
 1.12.0 (2016-03-30)

--- a/ftw/contentpage/browser/configure.zcml
+++ b/ftw/contentpage/browser/configure.zcml
@@ -85,14 +85,14 @@
 
     <browser:page
         for="*"
-        name="news_listing"
+        name="newslisting"
         class=".newslisting.NewsListing"
         permission="zope2.View"
         />
 
     <browser:page
         for="*"
-        name="news_portlet_listing"
+        name="newsportlet_listing"
         class=".newslisting.NewsPortletListing"
         permission="zope2.View"
         />

--- a/ftw/contentpage/portlets/configure.zcml
+++ b/ftw/contentpage/portlets/configure.zcml
@@ -7,7 +7,7 @@
     <include package="plone.app.portlets" />
 
      <plone:portlet
-         name="newsportlet"
+         name="contentpagenewsportlet"
          interface=".news_portlet.INewsPortlet"
          assignment=".news_portlet.Assignment"
          view_permission="zope2.View"
@@ -17,7 +17,7 @@
          />
 
      <plone:portlet
-         name="newsarchiveportlet"
+         name="contentpagenewsarchiveportlet"
          interface=".news_archive_portlet.INewsArchivePortlet"
          assignment=".news_archive_portlet.Assignment"
          view_permission="zope2.View"

--- a/ftw/contentpage/portlets/news_archive_portlet.py
+++ b/ftw/contentpage/portlets/news_archive_portlet.py
@@ -48,7 +48,7 @@ class Renderer(base.Renderer):
             self.request,
             ['ftw.contentpage.interfaces.INews'],
             'effective',
-            'news_listing')()
+            'newslisting')()
 
     render = ViewPageTemplateFile('news_archive_portlet.pt')
 

--- a/ftw/contentpage/portlets/news_portlet.py
+++ b/ftw/contentpage/portlets/news_portlet.py
@@ -336,7 +336,7 @@ class Renderer(base.Renderer):
             self.manager.__name__)
 
         return '/'.join((self.get_news_context().absolute_url(),
-                         '@@news_portlet_listing?{0}'.format(params)))
+                         '@@newsportlet_listing?{0}'.format(params)))
 
     def get_news_context(self):
         """ If we are in a news entry we have to get a parent node as start for

--- a/ftw/contentpage/profiles/default/metadata.xml
+++ b/ftw/contentpage/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>1610</version>
+    <version>1611</version>
     <dependencies>
         <dependency>profile-simplelayout.base:default</dependency>
         <dependency>profile-simplelayout.portlet.dropzone:default</dependency>

--- a/ftw/contentpage/profiles/default/types/NewsFolder.xml
+++ b/ftw/contentpage/profiles/default/types/NewsFolder.xml
@@ -11,16 +11,16 @@
  <property name="factory">addNewsFolder</property>
  <property name="add_view_expr"></property>
  <property name="link_target"></property>
- <property name="immediate_view">news_listing</property>
+ <property name="immediate_view">newslisting</property>
  <property name="global_allow">True</property>
  <property name="filter_content_types">True</property>
  <property name="allowed_content_types">
   <element value="News"/>
  </property>
  <property name="allow_discussion">False</property>
- <property name="default_view">news_listing</property>
+ <property name="default_view">newslisting</property>
  <property name="view_methods">
-  <element value="news_listing"/>
+  <element value="newslisting"/>
  </property>
  <property name="default_view_fallback">False</property>
  <alias from="(Default)" to="(dynamic view)"/>

--- a/ftw/contentpage/profiles/uninstall/portlets.xml
+++ b/ftw/contentpage/profiles/uninstall/portlets.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <portlets>
   <portlet
-   addview="newsportlet"
+   addview="contentpagenewsportlet"
    remove="True"
    />
  <portlet
-   addview="newsarchiveportlet"
+   addview="contentpagenewsarchiveportlet"
    remove="True"
    />
  <portlet

--- a/ftw/contentpage/profiles/uninstall/types/Topic.xml
+++ b/ftw/contentpage/profiles/uninstall/types/Topic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <object name="Topic">
  <property name="view_methods" purge="False">
-  <element value="news_listing" remove="True" />
+  <element value="newslisting" remove="True" />
  </property>
 </object>

--- a/ftw/contentpage/tests/builders.py
+++ b/ftw/contentpage/tests/builders.py
@@ -1,6 +1,6 @@
 from ftw.builder import builder_registry
 from ftw.builder.archetypes import ArchetypesBuilder
-from ftw.builder.content import ImageBuilder
+from ftw.builder.content import ATImageBuilder
 from ftw.contentpage.portlets import news_portlet
 from plone.portlets.interfaces import IPortletAssignmentMapping
 from plone.portlets.interfaces import IPortletManager
@@ -82,7 +82,7 @@ class ListingBlockBuilder(ArchetypesBuilder):
 builder_registry.register('listing block', ListingBlockBuilder)
 
 
-class TextBlockBuilder(ImageBuilder):
+class TextBlockBuilder(ATImageBuilder):
 
     portal_type = 'TextBlock'
 

--- a/ftw/contentpage/tests/test_archive_summary.py
+++ b/ftw/contentpage/tests/test_archive_summary.py
@@ -23,7 +23,7 @@ class TestArchiveSummary(TestCase):
             self.request,
             ['ftw.contentpage.interfaces.INews'],
             'effective',
-            'news_listing')
+            'newslisting')
 
     def _create_news(self, date_str):
         create(Builder('news')

--- a/ftw/contentpage/tests/test_news_portlets_functional.py
+++ b/ftw/contentpage/tests/test_news_portlets_functional.py
@@ -29,7 +29,7 @@ class TestNewsPortlets(unittest.TestCase):
     def _create_portlet(self):
         self.browser.open(
             self.portal.absolute_url() +
-            '/++contextportlets++plone.leftcolumn/+/newsportlet'
+            '/++contextportlets++plone.leftcolumn/+/contentpagenewsportlet'
             )
         self.browser.getControl(
             name="form.widgets.portlet_title").value = u"My Portlet"
@@ -75,7 +75,7 @@ class TestNewsPortlets(unittest.TestCase):
         self._create_content()
         self.browser.open(
             self.portal.absolute_url() +
-            '/++contextportlets++plone.leftcolumn/+/newsportlet'
+            '/++contextportlets++plone.leftcolumn/+/contentpagenewsportlet'
             )
         self.browser.getControl(
             name="form.widgets.portlet_title").value = u"My Portlet"
@@ -99,7 +99,7 @@ class TestNewsPortlets(unittest.TestCase):
         self._create_content()
         self.browser.open(
             self.portal.absolute_url() +
-            '/++contextportlets++plone.leftcolumn/+/newsportlet'
+            '/++contextportlets++plone.leftcolumn/+/contentpagenewsportlet'
             )
         self.browser.getControl(
             name="form.widgets.portlet_title").value = u"My Portlet"
@@ -121,7 +121,7 @@ class TestNewsPortlets(unittest.TestCase):
         self._create_content()
         self.browser.open(
             self.portal.absolute_url() +
-            '/++contextportlets++plone.leftcolumn/+/newsportlet'
+            '/++contextportlets++plone.leftcolumn/+/contentpagenewsportlet'
             )
         self.browser.getControl(
             name="form.widgets.portlet_title").value = u"My Portlet"
@@ -147,7 +147,7 @@ class TestNewsPortlets(unittest.TestCase):
         self._create_content()
         self.browser.open(
             self.portal.absolute_url() +
-            '/++contextportlets++plone.leftcolumn/+/newsportlet'
+            '/++contextportlets++plone.leftcolumn/+/contentpagenewsportlet'
             )
         self.browser.getControl(
             name="form.widgets.portlet_title").value = u"My Portlet"
@@ -181,7 +181,7 @@ class TestNewsPortlets(unittest.TestCase):
 
         self.browser.open(
             self.portal.absolute_url() +
-            '/++contextportlets++plone.leftcolumn/+/newsportlet')
+            '/++contextportlets++plone.leftcolumn/+/contentpagenewsportlet')
         self.browser.getControl(
             name="form.widgets.portlet_title").value = u"My Portlet"
         # Get Control over the Query Field and enter a value.
@@ -203,7 +203,7 @@ class TestNewsPortlets(unittest.TestCase):
     def test_no_classificationItems(self):
         self.browser.open(
             self.portal.absolute_url() +
-            '/++contextportlets++plone.leftcolumn/+/newsportlet')
+            '/++contextportlets++plone.leftcolumn/+/contentpagenewsportlet')
         self.assertNotIn('<div class="contenttreeWidget"'
                          'id="form-widgets-classification_items-contenttree">',
                          self.browser.contents
@@ -216,7 +216,7 @@ class TestNewsPortlets(unittest.TestCase):
         transaction.commit()
         self.browser.open(
             self.portal.absolute_url() +
-            '/++contextportlets++plone.leftcolumn/+/newsportlet'
+            '/++contextportlets++plone.leftcolumn/+/contentpagenewsportlet'
             )
         self.assertIn('<div class="contenttreeWidget"'
                       ' id="form-widgets-classification_items-contenttree">',
@@ -283,7 +283,7 @@ class TestNewsPortlets(unittest.TestCase):
     def test_addform_cancel(self):
         self.browser.open(
             self.portal.absolute_url() +
-            '/++contextportlets++plone.leftcolumn/+/newsportlet'
+            '/++contextportlets++plone.leftcolumn/+/contentpagenewsportlet'
         )
         self.browser.getControl(name="form.buttons.cancel_add").click()
         self.assertEqual(self.portal.absolute_url() + '/@@manage-portlets',
@@ -293,14 +293,14 @@ class TestNewsPortlets(unittest.TestCase):
         self._create_content()
         self.browser.open(
             self.portal.absolute_url() +
-            '/++contextportlets++plone.leftcolumn/+/newsportlet'
+            '/++contextportlets++plone.leftcolumn/+/contentpagenewsportlet'
         )
         self.browser.addHeader('Authorization', 'Basic %s:%s' % (
             TEST_USER_NAME, TEST_USER_PASSWORD, ))
 
         self.browser.open(
             self.portal.absolute_url() +
-            '/++contextportlets++plone.leftcolumn/+/newsportlet'
+            '/++contextportlets++plone.leftcolumn/+/contentpagenewsportlet'
         )
         # Get Control over the Query Field and enter a value.
         self.browser.getControl(
@@ -386,7 +386,7 @@ class TestNewsPortlets(unittest.TestCase):
                           'number': 2,
                           'title': u'January',
                           'url': 'http://nohost/plone/archivefolder/'
-                                 'news_listing?archive=2013/01/01'}],
+                                 'newslisting?archive=2013/01/01'}],
               'number': 2,
               'title': '2013'},
              {'mark': False,
@@ -394,7 +394,7 @@ class TestNewsPortlets(unittest.TestCase):
                           'number': 2,
                           'title': u'December',
                           'url': 'http://nohost/plone/archivefolder/'
-                                 'news_listing?archive=2012/12/01'}],
+                                 'newslisting?archive=2012/12/01'}],
               'number': 2,
               'title': '2012'}],
             renderer.archive_summary())
@@ -418,7 +418,7 @@ class TestNewsPortlets(unittest.TestCase):
             TEST_USER_NAME, TEST_USER_PASSWORD, ))
 
         self.browser.open(
-            '%s/++contextportlets++plone.leftcolumn/+/newsarchiveportlet' %
+            '%s/++contextportlets++plone.leftcolumn/+/contentpagenewsarchiveportlet' %
             self.newsfolder1.absolute_url()
         )
 

--- a/ftw/contentpage/tests/test_news_views.py
+++ b/ftw/contentpage/tests/test_news_views.py
@@ -55,7 +55,7 @@ class TestNewsViews(unittest.TestCase):
                 effectiveDate=None))
 
     def test_news_listing_view_no_restriction(self):
-        listing = self.newsfolder.restrictedTraverse("@@news_listing")
+        listing = self.newsfolder.restrictedTraverse("@@newslisting")
         self.assertEqual(len(listing.get_items()), 5)
         brain = listing.get_items()[0]
         self.assertEqual(brain.Title, 'My News')
@@ -66,7 +66,7 @@ class TestNewsViews(unittest.TestCase):
         self.assertEqual('test_user_1_', listing.get_creator(brain))
 
     def test_get_creator_no_member(self):
-        listing = self.newsfolder.restrictedTraverse("@@news_listing")
+        listing = self.newsfolder.restrictedTraverse("@@newslisting")
         self.news.setCreators(['dummy'])
         self.news.reindexObject()
 
@@ -74,7 +74,7 @@ class TestNewsViews(unittest.TestCase):
         self.assertEquals('dummy', listing.get_creator(brain))
 
     def test_get_creator_has_fullname(self):
-        listing = self.newsfolder.restrictedTraverse("@@news_listing")
+        listing = self.newsfolder.restrictedTraverse("@@newslisting")
         member = self.portal.portal_membership.getMemberById(TEST_USER_ID)
         member.setProperties(fullname='Firstname Lastname')
 
@@ -82,5 +82,5 @@ class TestNewsViews(unittest.TestCase):
         self.assertEquals('Firstname Lastname', listing.get_creator(brain))
 
     def test_news_listing_on_portal(self):
-        listing = self.portal.restrictedTraverse("@@news_listing")
+        listing = self.portal.restrictedTraverse("@@newslisting")
         self.assertEqual(len(listing.get_items()), 5)

--- a/ftw/contentpage/tests/test_newslisting.py
+++ b/ftw/contentpage/tests/test_newslisting.py
@@ -94,7 +94,7 @@ class TestNewsListing(TestCase):
         page = create(Builder('content page').titled('Contentpage'))
         newsfolder = create(Builder('news folder').within(page).titled('News'))
 
-        browser.login().visit(page, view='@@news_listing')
+        browser.login().visit(page, view='@@newslisting')
         self.assertEquals('Contentpage - News', plone.first_heading())
 
         browser.visit(newsfolder)

--- a/ftw/contentpage/tests/test_newsportlet_listing.py
+++ b/ftw/contentpage/tests/test_newsportlet_listing.py
@@ -18,14 +18,14 @@ class TestNewsPortletListing(TestCase):
 
     def test_no_portlet_found(self):
         self.request.form.update({'portlet': 'not_existing'})
-        view = self.portal.unrestrictedTraverse('news_portlet_listing')
+        view = self.portal.unrestrictedTraverse('newsportlet_listing')
         self.assertEqual(None, view.get_portlet())
 
     def test_portlet_found_in_leftcolumn(self):
         portlet = create(Builder('news portlet'))
         self.request.form.update({'portlet': portlet.__name__,
                                   'manager': u'plone.leftcolumn'})
-        view = self.portal.unrestrictedTraverse('news_portlet_listing')
+        view = self.portal.unrestrictedTraverse('newsportlet_listing')
         self.assertEqual(portlet,
                          view.get_portlet().data)
 

--- a/ftw/contentpage/upgrades/configure.zcml
+++ b/ftw/contentpage/upgrades/configure.zcml
@@ -434,4 +434,13 @@
         directory="profiles/1610"
         />
 
+    <!-- 1610 -> 1611 -->
+    <upgrade-step:importProfile
+        title="Update news view names - they changed in favior of ftw.news."
+        profile="ftw.contentpage:default"
+        source="1610"
+        destination="1611"
+        directory="profiles/1611"
+        />
+
 </configure>

--- a/ftw/contentpage/upgrades/profiles/1611/portlets.xml
+++ b/ftw/contentpage/upgrades/profiles/1611/portlets.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <portlets>
  <!-- Portlet type registrations -->
+
+ <portlet addview="newsportlet" remove="true" />
+ <portlet addview="newsarchiveportlet" remove="true" />
+
  <portlet
    addview="contentpagenewsportlet"
    title="News Portlet"
@@ -13,10 +17,5 @@
    description=""
    />
 
- <portlet
-   addview="eventarchive"
-   title="Event Archive Portlet"
-   description=""
-   />
 
 </portlets>

--- a/ftw/contentpage/upgrades/profiles/1611/types/NewsFolder.xml
+++ b/ftw/contentpage/upgrades/profiles/1611/types/NewsFolder.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<object name="NewsFolder"
+   meta_type="Factory-based Type Information with dynamic views"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+   i18n:domain="ftw.contentpage">
+
+ <property name="immediate_view">newslisting</property>
+
+ <property name="default_view">newslisting</property>
+
+ <property name="view_methods" purge="False">
+  <element value="news_listing" remove="True"/>
+  <element value="newslisting"/>
+ </property>
+
+</object>

--- a/ftw/contentpage/upgrades/profiles/1611/types/Topic.xml
+++ b/ftw/contentpage/upgrades/profiles/1611/types/Topic.xml
@@ -2,7 +2,10 @@
 <object name="Topic"
    meta_type="Factory-based Type Information with dynamic views"
    i18n:domain="plone" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
  <property name="view_methods" purge="False">
-  <element value="newslisting"/>
+  <element value="news_listing" remove="True"/>
+  <element value="newslisting" />
  </property>
+
 </object>

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-version = '1.12.1.dev0'
+version = '1.13.0.dev0'
 mainainter = 'Mathias Leimgruber'
 
 tests_require = ['ftw.testing [splinter]',


### PR DESCRIPTION
This PR also fixes the `ImageBuilder` import error. 

This change may break customer implementations. Hopefully you got tests!