### PR TITLE
Add option to override the title of the news archive portlets.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.14.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add option to override the title of the news archive portlets.
+  [mbaechtold]
 
 
 1.14.0 (2016-12-13)

--- a/ftw/contentpage/locales/de/LC_MESSAGES/ftw.contentpage.po
+++ b/ftw/contentpage/locales/de/LC_MESSAGES/ftw.contentpage.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-12-12 14:21+0000\n"
+"POT-Creation-Date: 2017-01-03 17:09+0000\n"
 "PO-Revision-Date: 2013-04-11 18:16+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,7 +34,7 @@ msgstr "Adresse"
 msgid "AddressBlock"
 msgstr "Adressenblock"
 
-#: ./ftw/contentpage/portlets/news_archive_portlet.pt:12
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:74
 msgid "Archive"
 msgstr "Archiv"
 
@@ -81,7 +81,7 @@ msgstr "Veranstaltung"
 msgid "EventFolder"
 msgstr "Veranstaltungsordner"
 
-#: ./ftw/contentpage/portlets/event_archive.py:73
+#: ./ftw/contentpage/portlets/event_archive.py:74
 msgid "Events"
 msgstr "Veranstaltungen"
 
@@ -259,32 +259,32 @@ msgid "description_image_clickable"
 msgstr "Wird das Bild angeklickt, öffnet es sich in einem Overlay"
 
 #. Default: "Renders a widget containing the number of events by year and month."
-#: ./ftw/contentpage/portlets/event_archive.py:83
+#: ./ftw/contentpage/portlets/event_archive.py:84
 msgid "event_archive_portlet_add_form_description"
 msgstr "Zeigt die Anzahl Veranstaltungen gruppiert nach Jahr und Monat an."
 
 #. Default: "Add Event Archive Portlet"
-#: ./ftw/contentpage/portlets/event_archive.py:81
+#: ./ftw/contentpage/portlets/event_archive.py:82
 msgid "event_archive_portlet_add_form_label"
-msgstr "Event Archive Portlet hinzufügen"
+msgstr "Event-Archiv Portlet hinzufügen"
 
 #. Default: "Renders a widget containing the number of events by year and month."
-#: ./ftw/contentpage/portlets/event_archive.py:136
+#: ./ftw/contentpage/portlets/event_archive.py:137
 msgid "event_archive_portlet_edit_form_description"
 msgstr "Zeigt die Anzahl Veranstaltungen gruppiert nach Jahr und Monat an."
 
 #. Default: "Edit Event Archive Portlet"
-#: ./ftw/contentpage/portlets/event_archive.py:134
+#: ./ftw/contentpage/portlets/event_archive.py:135
 msgid "event_archive_portlet_edit_form_label"
-msgstr "Event Archive Portlet bearbeiten"
+msgstr "Event-Archiv Portlet bearbeiten"
 
 #. Default: "Use this to override the title of the portlet."
-#: ./ftw/contentpage/portlets/event_archive.py:24
+#: ./ftw/contentpage/portlets/event_archive.py:25
 msgid "event_portlet_title_description"
 msgstr "Übersteuert den Standard-Titel des Portlets"
 
 #. Default: "Title"
-#: ./ftw/contentpage/portlets/event_archive.py:23
+#: ./ftw/contentpage/portlets/event_archive.py:24
 msgid "event_portlet_title_label"
 msgstr "Titel"
 
@@ -471,6 +471,8 @@ msgid "label_by_author"
 msgstr "von ${author}"
 
 #. Default: "Cancel"
+#: ./ftw/contentpage/portlets/event_archive.py:116
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:116
 #: ./ftw/contentpage/portlets/news_portlet.py:158
 msgid "label_cancel"
 msgstr "Abbrechen"
@@ -643,6 +645,8 @@ msgid "label_rss_link"
 msgstr "RSS-Feed Link anzeigen."
 
 #. Default: "Save"
+#: ./ftw/contentpage/portlets/event_archive.py:105
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:105
 #: ./ftw/contentpage/portlets/news_portlet.py:147
 msgid "label_save"
 msgstr "Speichern"
@@ -734,6 +738,36 @@ msgstr "E-Mail"
 #: ./ftw/contentpage/portlets/news_portlet.pt:57
 msgid "more_news_link"
 msgstr "Ältere Meldungen anzeigen"
+
+#. Default: "Renders a widget containing the number of news by year and month."
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:84
+msgid "news_archive_portlet_add_form_description"
+msgstr "Zeigt die Anzahl Meldungen gruppiert nach Jahr und Monat an."
+
+#. Default: "Add News Archive Portlet"
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:82
+msgid "news_archive_portlet_add_form_label"
+msgstr "News-Archiv Portlet hinzufügen"
+
+#. Default: "Edit News Archive Portlet"
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:135
+msgid "news_archive_portlet_edit_form_label"
+msgstr "News-Archiv Portlet bearbeiten"
+
+#. Default: "Use this to override the title of the portlet."
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:25
+msgid "news_archive_portlet_title_description"
+msgstr "Übersteuert den Standard-Titel des Portlets"
+
+#. Default: "Title"
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:24
+msgid "news_archive_portlet_title_label"
+msgstr "Titel"
+
+#. Default: "Renders a widget containing the number of news by year and month."
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:137
+msgid "newst_archive_portlet_edit_form_description"
+msgstr "Zeigt die Anzahl Meldungen gruppiert nach Jahr und Monat an."
 
 #. Default: "No recent news available."
 #: ./ftw/contentpage/portlets/news_portlet.pt:19

--- a/ftw/contentpage/locales/fr/LC_MESSAGES/ftw.contentpage.po
+++ b/ftw/contentpage/locales/fr/LC_MESSAGES/ftw.contentpage.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-12-12 14:21+0000\n"
+"POT-Creation-Date: 2017-01-03 17:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,7 +34,7 @@ msgstr ""
 msgid "AddressBlock"
 msgstr ""
 
-#: ./ftw/contentpage/portlets/news_archive_portlet.pt:12
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:74
 msgid "Archive"
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "EventFolder"
 msgstr ""
 
-#: ./ftw/contentpage/portlets/event_archive.py:73
+#: ./ftw/contentpage/portlets/event_archive.py:74
 msgid "Events"
 msgstr "Evénements"
 
@@ -259,32 +259,32 @@ msgid "description_image_clickable"
 msgstr "Ouvre l'image dans un overlay"
 
 #. Default: "Renders a widget containing the number of events by year and month."
-#: ./ftw/contentpage/portlets/event_archive.py:83
+#: ./ftw/contentpage/portlets/event_archive.py:84
 msgid "event_archive_portlet_add_form_description"
 msgstr ""
 
 #. Default: "Add Event Archive Portlet"
-#: ./ftw/contentpage/portlets/event_archive.py:81
+#: ./ftw/contentpage/portlets/event_archive.py:82
 msgid "event_archive_portlet_add_form_label"
 msgstr ""
 
 #. Default: "Renders a widget containing the number of events by year and month."
-#: ./ftw/contentpage/portlets/event_archive.py:136
+#: ./ftw/contentpage/portlets/event_archive.py:137
 msgid "event_archive_portlet_edit_form_description"
 msgstr ""
 
 #. Default: "Edit Event Archive Portlet"
-#: ./ftw/contentpage/portlets/event_archive.py:134
+#: ./ftw/contentpage/portlets/event_archive.py:135
 msgid "event_archive_portlet_edit_form_label"
 msgstr ""
 
 #. Default: "Use this to override the title of the portlet."
-#: ./ftw/contentpage/portlets/event_archive.py:24
+#: ./ftw/contentpage/portlets/event_archive.py:25
 msgid "event_portlet_title_description"
 msgstr ""
 
 #. Default: "Title"
-#: ./ftw/contentpage/portlets/event_archive.py:23
+#: ./ftw/contentpage/portlets/event_archive.py:24
 msgid "event_portlet_title_label"
 msgstr ""
 
@@ -471,6 +471,8 @@ msgid "label_by_author"
 msgstr "de ${author}"
 
 #. Default: "Cancel"
+#: ./ftw/contentpage/portlets/event_archive.py:116
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:116
 #: ./ftw/contentpage/portlets/news_portlet.py:158
 msgid "label_cancel"
 msgstr "Annuler"
@@ -643,6 +645,8 @@ msgid "label_rss_link"
 msgstr ""
 
 #. Default: "Save"
+#: ./ftw/contentpage/portlets/event_archive.py:105
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:105
 #: ./ftw/contentpage/portlets/news_portlet.py:147
 msgid "label_save"
 msgstr "Enregistrer"
@@ -734,6 +738,36 @@ msgstr ""
 #: ./ftw/contentpage/portlets/news_portlet.pt:57
 msgid "more_news_link"
 msgstr "Plus de nouvelles"
+
+#. Default: "Renders a widget containing the number of news by year and month."
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:84
+msgid "news_archive_portlet_add_form_description"
+msgstr ""
+
+#. Default: "Add News Archive Portlet"
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:82
+msgid "news_archive_portlet_add_form_label"
+msgstr ""
+
+#. Default: "Edit News Archive Portlet"
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:135
+msgid "news_archive_portlet_edit_form_label"
+msgstr ""
+
+#. Default: "Use this to override the title of the portlet."
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:25
+msgid "news_archive_portlet_title_description"
+msgstr ""
+
+#. Default: "Title"
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:24
+msgid "news_archive_portlet_title_label"
+msgstr ""
+
+#. Default: "Renders a widget containing the number of news by year and month."
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:137
+msgid "newst_archive_portlet_edit_form_description"
+msgstr ""
 
 #. Default: "No recent news available."
 #: ./ftw/contentpage/portlets/news_portlet.pt:19

--- a/ftw/contentpage/locales/ftw.contentpage.pot
+++ b/ftw/contentpage/locales/ftw.contentpage.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-12-12 14:21+0000\n"
+"POT-Creation-Date: 2017-01-03 17:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,7 +34,7 @@ msgstr ""
 msgid "AddressBlock"
 msgstr ""
 
-#: ./ftw/contentpage/portlets/news_archive_portlet.pt:12
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:74
 msgid "Archive"
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "EventFolder"
 msgstr ""
 
-#: ./ftw/contentpage/portlets/event_archive.py:73
+#: ./ftw/contentpage/portlets/event_archive.py:74
 msgid "Events"
 msgstr ""
 
@@ -259,32 +259,32 @@ msgid "description_image_clickable"
 msgstr ""
 
 #. Default: "Renders a widget containing the number of events by year and month."
-#: ./ftw/contentpage/portlets/event_archive.py:83
+#: ./ftw/contentpage/portlets/event_archive.py:84
 msgid "event_archive_portlet_add_form_description"
 msgstr ""
 
 #. Default: "Add Event Archive Portlet"
-#: ./ftw/contentpage/portlets/event_archive.py:81
+#: ./ftw/contentpage/portlets/event_archive.py:82
 msgid "event_archive_portlet_add_form_label"
 msgstr ""
 
 #. Default: "Renders a widget containing the number of events by year and month."
-#: ./ftw/contentpage/portlets/event_archive.py:136
+#: ./ftw/contentpage/portlets/event_archive.py:137
 msgid "event_archive_portlet_edit_form_description"
 msgstr ""
 
 #. Default: "Edit Event Archive Portlet"
-#: ./ftw/contentpage/portlets/event_archive.py:134
+#: ./ftw/contentpage/portlets/event_archive.py:135
 msgid "event_archive_portlet_edit_form_label"
 msgstr ""
 
 #. Default: "Use this to override the title of the portlet."
-#: ./ftw/contentpage/portlets/event_archive.py:24
+#: ./ftw/contentpage/portlets/event_archive.py:25
 msgid "event_portlet_title_description"
 msgstr ""
 
 #. Default: "Title"
-#: ./ftw/contentpage/portlets/event_archive.py:23
+#: ./ftw/contentpage/portlets/event_archive.py:24
 msgid "event_portlet_title_label"
 msgstr ""
 
@@ -471,6 +471,8 @@ msgid "label_by_author"
 msgstr ""
 
 #. Default: "Cancel"
+#: ./ftw/contentpage/portlets/event_archive.py:116
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:116
 #: ./ftw/contentpage/portlets/news_portlet.py:158
 msgid "label_cancel"
 msgstr ""
@@ -643,6 +645,8 @@ msgid "label_rss_link"
 msgstr ""
 
 #. Default: "Save"
+#: ./ftw/contentpage/portlets/event_archive.py:105
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:105
 #: ./ftw/contentpage/portlets/news_portlet.py:147
 msgid "label_save"
 msgstr ""
@@ -733,6 +737,36 @@ msgstr ""
 #. Default: "More News"
 #: ./ftw/contentpage/portlets/news_portlet.pt:57
 msgid "more_news_link"
+msgstr ""
+
+#. Default: "Renders a widget containing the number of news by year and month."
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:84
+msgid "news_archive_portlet_add_form_description"
+msgstr ""
+
+#. Default: "Add News Archive Portlet"
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:82
+msgid "news_archive_portlet_add_form_label"
+msgstr ""
+
+#. Default: "Edit News Archive Portlet"
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:135
+msgid "news_archive_portlet_edit_form_label"
+msgstr ""
+
+#. Default: "Use this to override the title of the portlet."
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:25
+msgid "news_archive_portlet_title_description"
+msgstr ""
+
+#. Default: "Title"
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:24
+msgid "news_archive_portlet_title_label"
+msgstr ""
+
+#. Default: "Renders a widget containing the number of news by year and month."
+#: ./ftw/contentpage/portlets/news_archive_portlet.py:137
+msgid "newst_archive_portlet_edit_form_description"
 msgstr ""
 
 #. Default: "No recent news available."

--- a/ftw/contentpage/portlets/configure.zcml
+++ b/ftw/contentpage/portlets/configure.zcml
@@ -23,6 +23,7 @@
          view_permission="zope2.View"
          renderer=".news_archive_portlet.Renderer"
          addview=".news_archive_portlet.AddForm"
+         editview=".news_archive_portlet.EditForm"
          />
 
      <plone:portlet

--- a/ftw/contentpage/portlets/news_archive_portlet.pt
+++ b/ftw/contentpage/portlets/news_archive_portlet.pt
@@ -8,10 +8,8 @@
     <div class="portletWrapper">
         <dl class="portlet portletArchiveListing">
 
-            <dt class="portletHeader">
-                <span i18n:translate="">
-                    Archive
-                </span>
+             <dt class="portletHeader">
+                <span tal:content="view/get_portlet_title"/>
             </dt>
 
             <dd class="portletItem">

--- a/ftw/contentpage/portlets/news_archive_portlet.py
+++ b/ftw/contentpage/portlets/news_archive_portlet.py
@@ -1,19 +1,39 @@
+from Acquisition._Acquisition import aq_inner
+from Acquisition._Acquisition import aq_parent
+from ftw.contentpage import _
 from ftw.contentpage.interfaces import INewsListingView
 from ftw.contentpage.portlets.base_archive_portlet import ArchiveSummary
+from plone.app.portlets.browser.interfaces import IPortletAddForm
+from plone.app.portlets.browser.interfaces import IPortletEditForm
+from plone.app.portlets.interfaces import IPortletPermissionChecker
 from plone.app.portlets.portlets import base
 from plone.memoize.view import memoize
 from plone.portlets.interfaces import IPortletDataProvider
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from z3c.form import form, button, field
+from zope import schema
+from zope.component import getMultiAdapter
+from zope.i18n import translate
 from zope.interface import implements
 
 
 class INewsArchivePortlet(IPortletDataProvider):
     """Archive portlet interface.
-"""
+    """
+    portlet_title = schema.TextLine(
+        title=_(u'news_archive_portlet_title_label', default=u'Title'),
+        description=_(u'news_archive_portlet_title_description',
+                      default=u'Use this to override the title of the portlet.'),
+        required=False,
+        default=u''
+    )
 
 
 class Assignment(base.Assignment):
     implements(INewsArchivePortlet)
+
+    def __init__(self, portlet_title=''):
+        self.portlet_title = portlet_title
 
     @property
     def title(self):
@@ -50,10 +70,108 @@ class Renderer(base.Renderer):
             'effective',
             'newslisting')()
 
+    def get_portlet_title(self):
+        default_title = translate(_(u'Archive'), context=self.request)
+        return getattr(self.data, 'portlet_title', '') or default_title
+
     render = ViewPageTemplateFile('news_archive_portlet.pt')
 
 
-class AddForm(base.NullAddForm):
+class AddForm(form.AddForm):
+    implements(IPortletAddForm)
+    label = _(u'news_archive_portlet_add_form_label',
+              default=u'Add News Archive Portlet')
+    description = _(u'news_archive_portlet_add_form_description',
+                    default=u'Renders a widget containing the number of news by year and month.')
 
-    def create(self):
-        return Assignment()
+    fields = field.Fields(INewsArchivePortlet)
+
+    def __init__(self, context, request):
+        super(AddForm, self).__init__(context, request)
+        self.status = None
+        self._finishedAdd = None
+
+    def __call__(self):
+        IPortletPermissionChecker(aq_parent(aq_inner(self.context)))()
+        return super(AddForm, self).__call__()
+
+    def nextURL(self):
+        editview = aq_parent(aq_inner(self.context))
+        context = aq_parent(aq_inner(editview))
+        url = str(getMultiAdapter((context, self.request),
+                                  name=u"absolute_url"))
+        return url + '/@@manage-portlets'
+
+    @button.buttonAndHandler(_(u"label_save", default=u"Save"), name='add')
+    def handleAdd(self, action):
+        data, errors = self.extractData()
+        if errors:
+            self.status = self.formErrorsMessage
+            return
+        obj = self.createAndAdd(data)
+        if obj is not None:
+            # mark only as finished if we get the new object
+            self._finishedAdd = True
+
+    @button.buttonAndHandler(_(u"label_cancel", default=u"Cancel"),
+                             name='cancel_add')
+    def handleCancel(self, action):
+        nextURL = self.nextURL()
+        return self.request.response.redirect(nextURL)
+
+    def add(self, object_):
+        ob = self.context.add(object_)
+        self._finishedAdd = True
+        return ob
+
+    def create(self, data):
+        return Assignment(
+            portlet_title=data.get('portlet_title', ''),
+        )
+
+
+class EditForm(form.EditForm):
+    implements(IPortletEditForm)
+    label = _(u'news_archive_portlet_edit_form_label',
+              default=u'Edit News Archive Portlet')
+    description = _(u'newst_archive_portlet_edit_form_description',
+                    default=u'Renders a widget containing the number of news by year and month.')
+
+    fields = field.Fields(INewsArchivePortlet)
+
+    def __init__(self, context, request):
+        super(EditForm, self).__init__(context, request)
+        self.status = None
+        self._finishedAdd = None
+
+    def __call__(self):
+        IPortletPermissionChecker(aq_parent(aq_inner(self.context)))()
+        return super(EditForm, self).__call__()
+
+    def nextURL(self):
+        editview = aq_parent(aq_inner(self.context))
+        context = aq_parent(aq_inner(editview))
+        url = str(getMultiAdapter((context, self.request),
+                                  name=u"absolute_url"))
+        return url + '/@@manage-portlets'
+
+    @button.buttonAndHandler(_(u"label_save", default=u"Save"), name='apply')
+    def handleSave(self, action):
+        data, errors = self.extractData()
+        if errors:
+            self.status = self.formErrorsMessage
+            return
+        changes = self.applyChanges(data)
+        if changes:
+            self.status = "Changes saved"
+        else:
+            self.status = "No changes"
+
+        nextURL = self.nextURL()
+        return self.request.response.redirect(nextURL)
+
+    @button.buttonAndHandler(_(u"label_cancel", default=u"Cancel"),
+                             name='cancel_edit')
+    def handleCancel(self, action):
+        nextURL = self.nextURL()
+        return self.request.response.redirect(nextURL)

--- a/ftw/contentpage/tests/builders.py
+++ b/ftw/contentpage/tests/builders.py
@@ -2,6 +2,7 @@ from ftw.builder import builder_registry
 from ftw.builder.archetypes import ArchetypesBuilder
 from ftw.builder.content import ATImageBuilder
 from ftw.builder.portlets import PlonePortletBuilder
+from ftw.contentpage.portlets import news_archive_portlet
 from ftw.contentpage.portlets import news_portlet
 from ftw.contentpage.portlets import event_archive
 from plone.portlets.interfaces import IPortletAssignmentMapping
@@ -163,3 +164,13 @@ class EventArchivePortletBuilder(PlonePortletBuilder):
         self.manager_name = u'plone.rightcolumn'
 
 builder_registry.register('event archive portlet', EventArchivePortletBuilder)
+
+
+class NewsArchivePortletBuilder(PlonePortletBuilder):
+    assignment_class = news_archive_portlet.Assignment
+
+    def __init__(self, session):
+        super(NewsArchivePortletBuilder, self).__init__(session)
+        self.manager_name = u'plone.rightcolumn'
+
+builder_registry.register('news archive portlet', NewsArchivePortletBuilder)

--- a/ftw/contentpage/tests/test_news_archive_portlet.py
+++ b/ftw/contentpage/tests/test_news_archive_portlet.py
@@ -1,0 +1,89 @@
+from DateTime import DateTime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.contentpage.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+
+
+class TestNewsArchivePortlet(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestNewsArchivePortlet, self).setUp()
+        self.grant('Manager')
+
+    @browsing
+    def test_news_archive_portlet(self, browser):
+        news_folder = create(Builder('news folder'))
+
+        create(Builder('news')
+               .within(news_folder)
+               .having(effectiveDate=DateTime(2013, 3, 20, 10, 0)))
+
+        create(Builder('news')
+               .within(news_folder)
+               .having(effectiveDate=DateTime(2013, 5, 26, 10, 0)))
+
+        create(Builder('news')
+               .within(news_folder)
+               .having(effectiveDate=DateTime(2013, 6, 28, 10, 0)))
+
+        create(Builder('news archive portlet').within(news_folder))
+
+        browser.login().visit(news_folder)
+
+        self.assertTrue(
+            browser.css('.portlet.portletArchiveListing'),
+            msg='There should be an news archive portlet, but it isn\'t.'
+        )
+
+        self.assertEqual(
+            3,
+            len(browser.css('.portlet.portletArchiveListing .portletItem li.month')),
+            msg='There should be 3 entries in the news archive portlet.'
+        )
+
+    @browsing
+    def test_news_archive_portlet_renders_default_title(self, browser):
+        news_folder = create(Builder('news folder'))
+
+        create(Builder('news')
+               .within(news_folder)
+               .having(effectiveDate=DateTime(2014, 2, 2)))
+
+        create(Builder('news archive portlet').within(news_folder))
+
+        browser.login().visit(news_folder)
+        self.assertEqual(
+            ['Archive'],
+            browser.css('dl.portletArchiveListing dt').text
+        )
+
+    @browsing
+    def test_news_archive_portlet_renders_custom_title(self, browser):
+        news_folder = create(Builder('news folder'))
+
+        create(Builder('news')
+               .within(news_folder)
+               .having(effectiveDate=DateTime(2014, 2, 2)))
+
+        create(Builder('news archive portlet').within(news_folder))
+        browser.login()
+
+        # Make sure the portlet renders the default title.
+        browser.visit(news_folder)
+        self.assertEqual(
+            ['Archive'],
+            browser.css('dl.portletArchiveListing dt').text
+        )
+
+        # Now let's change the title of the portlet.
+        browser.visit(news_folder, view='@@manage-portlets')
+        browser.find('News Archive Portlet').click()
+        browser.fill({'Title': u'Our Custom Title'}).submit()
+
+        # Make sure the portlet renders the custom title.
+        browser.visit(news_folder)
+        self.assertEqual(
+            ['Our Custom Title'],
+            browser.css('dl.portletArchiveListing dt').text
+        )

--- a/ftw/contentpage/tests/test_news_portlets_functional.py
+++ b/ftw/contentpage/tests/test_news_portlets_functional.py
@@ -412,28 +412,6 @@ class TestNewsPortlets(unittest.TestCase):
             'News Archive portlet should be available on NewsListing View'
         )
 
-    def test_news_archive_portlet(self):
-        self._create_content()
-        self.browser.addHeader('Authorization', 'Basic %s:%s' % (
-            TEST_USER_NAME, TEST_USER_PASSWORD, ))
-
-        self.browser.open(
-            '%s/++contextportlets++plone.leftcolumn/+/contentpagenewsarchiveportlet' %
-            self.newsfolder1.absolute_url()
-        )
-
-        self.browser.open(self.newsfolder1.absolute_url())
-
-        pq = PyQuery(self.browser.contents)
-        self.assertTrue(
-            pq('.portlet.portletArchiveListing'),
-            'We added one, so there should be a news archive portlet'
-        )
-
-        self.assertGreater(
-            len(pq('.portlet.portletArchiveListing .portletItem li')), 0,
-            'Expect at least one entry in the events archive portlet')
-
     def test_newsportlet_more_news_link_disabled(self):
         manager = getUtility(IPortletManager, name=u"plone.leftcolumn")
         portlet = NewsAssignment()


### PR DESCRIPTION
This is based on the implementation for the event archive portlet in https://github.com/4teamwork/ftw.contentpage/pull/237