### PR TITLE
Implement EventCreator for EventPage.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.15.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Implement ftw.calendar EventCreator for EventPage.
+  [lknoepfel]
 
 
 1.15.0 (2017-01-04)

--- a/ftw/contentpage/adapters.py
+++ b/ftw/contentpage/adapters.py
@@ -1,0 +1,21 @@
+from ftw.calendar.browser.interfaces import IFtwCalendarEventCreator
+from plone import api
+from zope.interface import implements
+
+
+class CalendarEventPageCreator(object):
+    implements(IFtwCalendarEventCreator)
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def getEventType(self):
+        return "EventPage"
+
+    def createEvent(self, title, start_date):
+        return api.content.create(container=self.context,
+                                  type=self.getEventType(),
+                                  title=title,
+                                  startDate=start_date,
+                                  endDate=start_date)

--- a/ftw/contentpage/configure.zcml
+++ b/ftw/contentpage/configure.zcml
@@ -131,5 +131,12 @@
        handler="simplelayout.base.events.set_initial_layout"
        />
 
+  <configure zcml:condition="installed ftw.calendar">
+      <adapter
+           for="* *"
+           provides="ftw.calendar.browser.interfaces.IFtwCalendarEventCreator"
+           factory=".adapters.CalendarEventPageCreator"
+           />
+  </configure>
 
 </configure>

--- a/ftw/contentpage/tests/test_event_creator_adapter.py
+++ b/ftw/contentpage/tests/test_event_creator_adapter.py
@@ -1,0 +1,37 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.calendar.browser.interfaces import IFtwCalendarEventCreator
+from ftw.contentpage.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+from zope.component import getMultiAdapter
+from DateTime import DateTime
+
+
+class TestEventCreatorAdapter(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestEventCreatorAdapter, self).setUp()
+        self.grant('Manager')
+
+    def test_event_creator_adapter_type(self):
+
+        eventCreator = getMultiAdapter((self.portal, self.request),
+                                       IFtwCalendarEventCreator)
+
+        self.assertEqual("EventPage", eventCreator.getEventType())
+
+    @browsing
+    def test_event_creator_adapter(self, browser):
+        event_folder = create(Builder('event folder'))
+
+        eventCreator = getMultiAdapter((event_folder, self.request),
+                                       IFtwCalendarEventCreator)
+
+        now = DateTime()
+
+        event = eventCreator.createEvent("test", now)
+
+        self.assertEqual('test', event.Title())
+        self.assertEqual(now, event.start())
+
+

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ tests_require = ['ftw.testing [splinter]',
                  'plone.app.testing',
                  'plone.mocktestcase',
                  'plone.formwidget.contenttree',
+                 'ftw.calendar >= 3.0.0',
                  'pyquery',
                  ]
 


### PR DESCRIPTION
Uses https://github.com/4teamwork/ftw.calendar/pull/19

This PR uses the new `ftw.calendar` feature to create events with a click on the calendar.