### PR TITLE
Make the news portlet more robust.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.16.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Make news portlet more robust.
+  [mbaechtold]
 
 
 1.16.0 (2017-01-30)

--- a/ftw/contentpage/portlets/news_portlet.py
+++ b/ftw/contentpage/portlets/news_portlet.py
@@ -325,7 +325,7 @@ class Renderer(base.Renderer):
         return ploneview.cropText(description, self.data.desc_length)
 
     def show_more_news_link(self):
-        return self.data.more_news_link
+        return getattr(self.data, 'more_news_link', False)
 
     def show_rss_link(self):
         return getattr(self.data, 'rss_link', False)


### PR DESCRIPTION
Portlets which were created before the feature "show more news link" landed in "ftw.contentpage" used to raise an error:

2017-01-31 15:59:54 ERROR portlets Error while determining renderer availability of portlet ('context' '/www.bgbern.ch/platform/burgergemeinde/behoerden/burgerliche-kindes-und-erwachsenenschutzbehoerde' u'news-portlet'): available
Traceback (most recent call last):
  File "/Users/mbaechtold/.buildout/eggs/plone.portlets-2.2-py2.7.egg/plone/portlets/manager.py", line 117, in _lazyLoadPortlets
    isAvailable = renderer.available
AttributeError: available