### PR TITLE
Pin "ftw.testing" down to a version having the "splinter" extra.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 version = '1.16.1.dev0'
 mainainter = 'Mathias Leimgruber'
 
-tests_require = ['ftw.testing [splinter]',
+tests_require = ['ftw.testing [splinter] <1.12.0',
                  'ftw.testbrowser',
                  'ftw.builder',
                  'plone.app.testing',


### PR DESCRIPTION
The "splinter" extra has been removed in ftw.testing 1.12.0. ftw.testbrowser should be used instead. There are many tests which need to be changed for this, so we're just pinning down "ftw.testing". Switching to "ftw.testbrowser" should be done at some time, thus an issue has been created: https://github.com/4teamwork/ftw.contentpage/issues/241