### PR TITLE
Fix event creator adapter.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.16.1 (unreleased)
 -------------------
 
+- Fix event creator adapter introduced in 1.16.0.
+  [mbaechtold]
+
 - Make news portlet more robust.
   [mbaechtold]
 

--- a/ftw/contentpage/adapters.py
+++ b/ftw/contentpage/adapters.py
@@ -14,8 +14,15 @@ class CalendarEventPageCreator(object):
         return "EventPage"
 
     def createEvent(self, title, start_date):
-        return api.content.create(container=self.context,
-                                  type=self.getEventType(),
-                                  title=title,
-                                  startDate=start_date,
-                                  endDate=start_date)
+        event = api.content.create(
+            container=self.context,
+            type=self.getEventType(),
+            title=title,
+        )
+
+        # Setting the dates does not work via "api.content.create()", reason unknown.
+        event.setStartDate(start_date)
+        event.setEndDate(start_date)
+        event.reindexObject(idxs=['start', 'end'])
+
+        return event


### PR DESCRIPTION
Setting "startDate" and "endDate" through "api.content.create()" does not work, resulting in None values. The reason for this is beyond my knowledge. The fact that the tests passed during the initial implementation may hint to a change in "plone.api".