### PR TITLE
Rewrite tests using "ftw.testbrowser".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.16.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Rewrite tests using "ftw.testbrowser", drop dependency on "ftw.testing[splinter]".
+  [mbaechtold]
 
 
 1.16.1 (2017-06-21)

--- a/ftw/contentpage/testing.py
+++ b/ftw/contentpage/testing.py
@@ -1,9 +1,9 @@
 from ftw.builder.session import BuilderSession
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import set_builder_session_factory
-from ftw.testing import FunctionalSplinterTesting
 from ftw.testing.layer import ComponentRegistryLayer
 from plone.app.testing import applyProfile
+from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
@@ -88,7 +88,7 @@ class FtwContentPageLayer(PloneSandboxLayer):
         login(portal, TEST_USER_NAME)
 
 
-class FunctionalBrowserlayerTesting(FunctionalSplinterTesting):
+class FunctionalBrowserlayerTesting(FunctionalTesting):
     """Support browserlayer"""
 
     def setUpEnvironment(self, portal):

--- a/ftw/contentpage/tests/pages.py
+++ b/ftw/contentpage/tests/pages.py
@@ -1,45 +1,50 @@
-from ftw.testing import browser
-from ftw.testing.pages import Plone
+from ftw.testbrowser import browser as default_browser
+from plone import api
 
 INDEX_XPATH = '//*[contains(concat(" ", normalize-space(@class), " "), ' + \
     '" letter-index ")]'
 
 
-class SubjectListingView(Plone):
+class SubjectListingView(object):
+    
+    def __init__(self, browser=default_browser):
+        self.browser = browser
+        self.portal = api.portal.get()
 
     def visit(self):
-        self.visit_portal('@@subject-listing')
-        self.assert_body_class('template-subject-listing')
+        self.browser.visit(self.portal, view='@@subject-listing')
+        assert 'template-subject-listing' in self.browser.css('body').first.classes, \
+            'Expected class is not available on the body-tag'
         return self
 
     @property
     def current_letter(self):
         return map(self._item_to_text,
-                   browser().find_by_css('.letter-index .current'))[0]
+                   self.browser.css('.letter-index .current'))[0]
 
     @property
     def linked_letters(self):
         return map(self._item_to_text,
-                   browser().find_by_css('.letter-index a'))
+                   self.browser.css('.letter-index a'))
 
     @property
     def mimetype_images(self):
-        return browser().find_by_css('.subject-mimetype-icon')
+        return self.browser.css('.subject-mimetype-icon')
 
     def click_letter(self, letter):
         xpath = INDEX_XPATH + '//a[normalize-space(text())="%s"]' % letter
-        elements = browser().find_by_xpath(xpath)
+        elements = self.browser.xpath(xpath)
         if len(elements) == 0:
             raise Exception('Letter-link for "%s" not found' % letter)
-        elements.click()
+        elements.first.click()
 
     @property
     def subjects(self):
-        subjects = browser().find_by_css('.subject')
+        subjects = self.browser.css('.subject')
         return map(self._item_to_text, subjects)
 
     def get_links_for(self, subject, text_only=False):
-        links = browser().find_by_xpath(
+        links = self.browser.xpath(
             '//td[normalize-space(text())="%s"]/..//a' % subject)
 
         if text_only:
@@ -48,40 +53,44 @@ class SubjectListingView(Plone):
             return links
 
     def _item_to_text(self, item):
-        return self.normalize_whitespace(item.text.strip())
+        return item.text
 
     def visit_with_subject_filter(self, value):
-        self.visit_portal('@@subject-listing?subject_filter={0}'.format(value))
-        self.assert_body_class('template-subject-listing')
+        self.browser.visit(self.portal.absolute_url() + '/@@subject-listing?subject_filter={0}'.format(value))
+        assert 'template-subject-listing' in self.browser.css('body').first.classes, \
+            'Expected class is not available on the body-tag'
         return self
 
 
-class AuthoritiesView(Plone):
+class AuthoritiesView(object):
+    
+    def __init__(self, browser=default_browser):
+        self.browser = browser
 
     def visit_on(self, page):
-        return self.visit(page, 'authorities_view')
+        return self.browser.visit(page, view='authorities_view')
 
     @property
     def link_labels(self):
-        return map(self._item_to_text, browser().find_by_css('#authorities a'))
+        return map(self._item_to_text, self.browser.css('#authorities a'))
 
     @property
     def link_labels_per_column(self):
         columns = []
-        for column in browser().find_by_css('#authorities .listing-column'):
+        for column in self.browser.css('#authorities .listing-column'):
             columns.append(map(self._item_to_text,
-                               column.find_by_css('a')))
+                               column.css('a')))
         return columns
 
     def link_url(self, label):
-        links = browser().find_by_xpath(
+        links = self.browser.xpath(
             '//*[@id="authorities"]//a[normalize-space(text())="%s"]' % label.strip())
 
         assert len(links) > 0, 'Link with text "%s" not found' % label.strip()
         assert len(links) == 1, 'More than one link with text "%s" found' % (
             label.strip())
 
-        return links[0]['href']
+        return links.first.attrib['href']
 
     def _item_to_text(self, item):
-        return self.normalize_whitespace(item.text.strip())
+        return item.text

--- a/ftw/contentpage/tests/test_authorities_view.py
+++ b/ftw/contentpage/tests/test_authorities_view.py
@@ -2,12 +2,10 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.contentpage.browser import authorities
 from ftw.contentpage.interfaces import IAuthority
-from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
+from ftw.contentpage.tests import FunctionalTestCase
 from ftw.contentpage.tests.pages import AuthoritiesView
+from ftw.testbrowser import browsing
 from ftw.testing import MockTestCase
-from plone.app.testing import setRoles
-from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
 import transaction
 
 
@@ -74,15 +72,14 @@ class TestHelperFunctions(MockTestCase):
              ])
 
 
-class TestTreeView(TestCase):
-
-    layer = FTW_CONTENTPAGE_FUNCTIONAL_TESTING
+class TestTreeView(FunctionalTestCase):
 
     def setUp(self):
-        self.portal = self.layer['portal']
-        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        super(TestTreeView, self).setUp()
+        self.grant('Manager')
 
-    def test_only_first_two_levels_visible(self):
+    @browsing
+    def test_only_first_two_levels_visible(self, browser):
         container = create(Builder('content page'))
 
         first = create(Builder('content page')
@@ -103,7 +100,8 @@ class TestTreeView(TestCase):
         AuthoritiesView().visit_on(container)
         self.assertEquals(['First', 'Second'], AuthoritiesView().link_labels)
 
-    def test_view_has_two_columns(self):
+    @browsing
+    def test_view_has_two_columns(self, browser):
         container = create(Builder('content page'))
 
         create(Builder('content page')
@@ -120,7 +118,8 @@ class TestTreeView(TestCase):
         self.assertEquals([['One'], ['Two']],
                           AuthoritiesView().link_labels_per_column)
 
-    def test_only_pages_with_orgunit_marker_interface_are_displayed(self):
+    @browsing
+    def test_only_pages_with_orgunit_marker_interface_are_displayed(self, browser):
         container = create(Builder('content page'))
 
         create(Builder('content page')
@@ -136,7 +135,8 @@ class TestTreeView(TestCase):
         self.assertEquals(['With IAuthority'],
                           AuthoritiesView().link_labels)
 
-    def test_pages_are_linked_properly(self):
+    @browsing
+    def test_pages_are_linked_properly(self, browser):
         container = create(Builder('content page'))
 
         foo = create(Builder('content page')
@@ -157,7 +157,8 @@ class TestTreeView(TestCase):
             [AuthoritiesView().link_url('Foo'),
              AuthoritiesView().link_url('Bar')])
 
-    def test_column_balancing_can_be_changed_with_property(self):
+    @browsing
+    def test_column_balancing_can_be_changed_with_property(self, browser):
         container = create(Builder('content page'))
 
         create(Builder('content page')
@@ -192,7 +193,8 @@ class TestTreeView(TestCase):
                            ['Two', 'Three', 'Four']],
                           AuthoritiesView().link_labels_per_column)
 
-    def test_pages_excluded_from_navigation_are_not_shown(self):
+    @browsing
+    def test_pages_excluded_from_navigation_are_not_shown(self, browser):
         container = create(Builder('content page'))
 
         create(Builder('content page')

--- a/ftw/contentpage/tests/test_subject_listing.py
+++ b/ftw/contentpage/tests/test_subject_listing.py
@@ -2,9 +2,9 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.contentpage.browser.subject_listing import make_sortable
 from ftw.contentpage.browser.subject_listing import normalized_first_letter
-from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
+from ftw.contentpage.tests import FunctionalTestCase
 from ftw.contentpage.tests.pages import SubjectListingView
-from ftw.testing import browser
+from ftw.testbrowser import browsing
 from plone.registry.interfaces import IRegistry
 from unittest2 import TestCase
 from zope.component import getUtility
@@ -35,11 +35,10 @@ class TestMakeSortable(TestCase):
                           make_sortable('fran\xc3\xa7ais'))
 
 
-class TestAlphabeticalSubjectListing(TestCase):
+class TestAlphabeticalSubjectListing(FunctionalTestCase):
 
-    layer = FTW_CONTENTPAGE_FUNCTIONAL_TESTING
-
-    def test_subjects_are_ordered_alphabetically(self):
+    @browsing
+    def test_subjects_are_ordered_alphabetically(self, browser):
         create(Builder('content page')
                .having(subject=['Airport']))
 
@@ -51,7 +50,8 @@ class TestAlphabeticalSubjectListing(TestCase):
         self.assertEquals(['Address modification', 'Airport', 'AZ'],
                           view.subjects)
 
-    def test_subjects_with_umlauts_are_ordered_correctly(self):
+    @browsing
+    def test_subjects_with_umlauts_are_ordered_correctly(self, browser):
         create(Builder('content page')
                .having(subject=['Grippe',
                                 'Gr\xc3\xa4ber']))
@@ -61,7 +61,8 @@ class TestAlphabeticalSubjectListing(TestCase):
                            'Grippe'.decode('utf-8')],
                           view.subjects)
 
-    def test_content_links_are_ordered_alphabetically(self):
+    @browsing
+    def test_content_links_are_ordered_alphabetically(self, browser):
         create(Builder('content page')
                .titled('Foo')
                .having(subject=['Airport']))
@@ -76,7 +77,8 @@ class TestAlphabeticalSubjectListing(TestCase):
         self.assertEquals(['Bar', 'BAZ', 'Foo'],
                           view.get_links_for('Airport', text_only=True))
 
-    def test_content_links_with_umlauts_are_ordered_correctly(self):
+    @browsing
+    def test_content_links_with_umlauts_are_ordered_correctly(self, browser):
         create(Builder('content page')
                .titled('G\xc3\xa4rtnerei')
                .having(subject=['Garten']))
@@ -90,22 +92,25 @@ class TestAlphabeticalSubjectListing(TestCase):
                            'Gr\xc3\xbcnfl\xc3\xa4chen'.decode('utf-8')],
                           view.get_links_for('Garten', text_only=True))
 
-    def test_content_is_properly_linked(self):
+    @browsing
+    def test_content_is_properly_linked(self, browser):
         page = create(Builder('content page')
                       .having(subject=['Airport']))
 
         view = SubjectListingView().visit()
         view.get_links_for('Airport').first.click()
-        self.assertEquals(page.absolute_url(), browser().url)
+        self.assertEquals(page.absolute_url(), browser.url)
 
-    def test_first_letter_with_content_is_selected(self):
+    @browsing
+    def test_first_letter_with_content_is_selected(self, browser):
         create(Builder('content page')
                .having(subject=['building application', 'crafting', '3D']))
 
         view = SubjectListingView().visit()
         self.assertEquals('B', view.current_letter)
 
-    def test_only_letters_with_content_are_linked(self):
+    @browsing
+    def test_only_letters_with_content_are_linked(self, browser):
         create(Builder('content page')
                .having(subject=['building application',
                                 'crafting',
@@ -114,7 +119,8 @@ class TestAlphabeticalSubjectListing(TestCase):
         view = SubjectListingView().visit()
         self.assertEquals(['B', 'C', 'M'], view.linked_letters)
 
-    def test_navigating_in_letter_index(self):
+    @browsing
+    def test_navigating_in_letter_index(self, browser):
         create(Builder('content page')
                .having(subject=['building application',
                                 'crafting',
@@ -125,7 +131,8 @@ class TestAlphabeticalSubjectListing(TestCase):
         view.click_letter('C')
         self.assertEquals('C', view.current_letter)
 
-    def test_only_content_of_current_is_listed(self):
+    @browsing
+    def test_only_content_of_current_is_listed(self, browser):
         create(Builder('content page')
                .having(subject=['building application',
                                 'budget',
@@ -143,7 +150,8 @@ class TestAlphabeticalSubjectListing(TestCase):
         self.assertEquals(['crafting'],
                           view.subjects)
 
-    def test_umlauts_are_normalized_for_letter_index(self):
+    @browsing
+    def test_umlauts_are_normalized_for_letter_index(self, browser):
         create(Builder('content page')
                .having(subject=['\xc3\xa4bc']))
 
@@ -151,7 +159,8 @@ class TestAlphabeticalSubjectListing(TestCase):
         self.assertEquals('A', view.current_letter)
         self.assertEquals([u'\xe4bc'], view.subjects)
 
-    def test_non_alphabetic_subjects_are_listed_under_number_sign(self):
+    @browsing
+    def test_non_alphabetic_subjects_are_listed_under_number_sign(self, browser):
         create(Builder('content page')
                .having(subject=['3D',
                                 '_X']))
@@ -160,7 +169,8 @@ class TestAlphabeticalSubjectListing(TestCase):
         view.click_letter('#')
         self.assertEquals(['3D', '_X'], view.subjects)
 
-    def test_lists_only_content_pages_by_default(self):
+    @browsing
+    def test_lists_only_content_pages_by_default(self, browser):
         create(Builder('content page')
                .titled('A page')
                .having(subject=['budget']))
@@ -173,7 +183,8 @@ class TestAlphabeticalSubjectListing(TestCase):
         self.assertEquals(['A page'],
                           view.get_links_for('budget', text_only=True))
 
-    def test_listed_types_are_configurable_in_registry(self):
+    @browsing
+    def test_listed_types_are_configurable_in_registry(self, browser):
         registry = getUtility(IRegistry)
         registry['ftw.contentpage.subjectlisting.portal_types'] = [
             u'ContentPage',
@@ -191,14 +202,16 @@ class TestAlphabeticalSubjectListing(TestCase):
         self.assertEquals(['A news', 'A page'],
                           view.get_links_for('budget', text_only=True))
 
-    def test_visiting_page_with_no_contents_does_not_crash(self):
+    @browsing
+    def test_visiting_page_with_no_contents_does_not_crash(self, browser):
         SubjectListingView().visit()
 
         self.assertEquals(
-            'There is no content to list.',
-            browser().find_by_css('#content .no-contents').text.strip())
+            ['There is no content to list.'],
+            browser.css('#content .no-contents').text)
 
-    def test_dont_show_mimetype_icon_per_default(self):
+    @browsing
+    def test_dont_show_mimetype_icon_per_default(self, browser):
         create(Builder('content page')
                .titled('A page')
                .having(subject=['budget']))
@@ -206,7 +219,8 @@ class TestAlphabeticalSubjectListing(TestCase):
         view = SubjectListingView().visit()
         self.assertEquals([], view.mimetype_images)
 
-    def test_show_mimetype_icon_if_set_in_registry(self):
+    @browsing
+    def test_show_mimetype_icon_if_set_in_registry(self, browser):
         registry = getUtility(IRegistry)
         registry['ftw.contentpage.subjectlisting.show_mimetype_icon'] = True
 
@@ -217,7 +231,8 @@ class TestAlphabeticalSubjectListing(TestCase):
         view = SubjectListingView().visit()
         self.assertEquals(1, len(view.mimetype_images))
 
-    def test_filter_subjects_if_context_property_is_set(self):
+    @browsing
+    def test_filter_subjects_if_context_property_is_set(self, browser):
         create(Builder('content page')
                .titled('A page')
                .having(subject=['A budget', 'A finance']))
@@ -234,7 +249,8 @@ class TestAlphabeticalSubjectListing(TestCase):
 
         self.assertEquals([u'A finance'], view.subjects)
 
-    def test_filter_subjects_if_request_variable_is_set(self):
+    @browsing
+    def test_filter_subjects_if_request_variable_is_set(self, browser):
         create(Builder('content page')
                .titled('A page')
                .having(subject=['A budget', 'A finance']))
@@ -247,7 +263,8 @@ class TestAlphabeticalSubjectListing(TestCase):
 
         self.assertEquals([u'A finance'], view.subjects)
 
-    def test_request_filter_wins_agains_context_property(self):
+    @browsing
+    def test_request_filter_wins_agains_context_property(self, browser):
         create(Builder('content page')
                .titled('A page')
                .having(subject=['A budget', 'A finance']))
@@ -264,7 +281,8 @@ class TestAlphabeticalSubjectListing(TestCase):
 
         self.assertEquals([u'A finance'], view.subjects)
 
-    def test_ignore_the_filtered_subject_in_the_listing(self):
+    @browsing
+    def test_ignore_the_filtered_subject_in_the_listing(self, browser):
         create(Builder('content page')
                .titled('A page')
                .having(subject=['A budget', 'A finance', 'A money']))
@@ -277,7 +295,8 @@ class TestAlphabeticalSubjectListing(TestCase):
 
         self.assertEquals([u'A earn', 'A finance', 'A money'], view.subjects)
 
-    def test_only_list_subjects_related_to_objects_with_filtered_subject(self):
+    @browsing
+    def test_only_list_subjects_related_to_objects_with_filtered_subject(self, browser):
         create(Builder('content page')
                .titled('A page')
                .having(subject=['A budget', 'A finance', 'A money']))
@@ -290,7 +309,8 @@ class TestAlphabeticalSubjectListing(TestCase):
 
         self.assertEquals([u'A finance', 'A money'], view.subjects)
 
-    def test_letters_assumes_subject_filter(self):
+    @browsing
+    def test_letters_assumes_subject_filter(self, browser):
         create(Builder('content page')
                .titled('A page')
                .having(subject=['budget', 'finance', 'money']))
@@ -309,7 +329,8 @@ class TestAlphabeticalSubjectListing(TestCase):
 
         self.assertEquals(['F', 'M'], view.linked_letters)
 
-    def test_not_break_if_filtered_subject_have_no_additional_subjects(self):
+    @browsing
+    def test_not_break_if_filtered_subject_have_no_additional_subjects(self, browser):
         create(Builder('content page')
                .titled('A page')
                .having(subject=['budget']))
@@ -317,5 +338,5 @@ class TestAlphabeticalSubjectListing(TestCase):
         SubjectListingView().visit_with_subject_filter('budget')
 
         self.assertEquals(
-            'There is no content to list.',
-            browser().find_by_css('#content .no-contents').text.strip())
+            ['There is no content to list.'],
+            browser.css('#content .no-contents').text)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 version = '1.16.2.dev0'
 mainainter = 'Mathias Leimgruber'
 
-tests_require = ['ftw.testing [splinter] <1.12.0',
+tests_require = ['ftw.testing',
                  'ftw.testbrowser',
                  'ftw.builder',
                  'plone.app.testing',


### PR DESCRIPTION
This is needed because "ftw.testing" 1.12.0 removed the "splinter" extra.

Closes https://github.com/4teamwork/ftw.contentpage/issues/241