### PR TITLE
Update newslisting_rss view to rss version 2.0

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.16.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Update newslisting rss view to rss version 2.0 [raphael-s]
 
 
 1.16.2 (2017-06-23)

--- a/ftw/contentpage/browser/newslisting_rss.pt
+++ b/ftw/contentpage/browser/newslisting_rss.pt
@@ -1,44 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rdf:RDF
-  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-  xmlns:dc="http://purl.org/dc/elements/1.1/"
-  xmlns:syn="http://purl.org/rss/1.0/modules/syndication/"
-  xmlns="http://purl.org/rss/1.0/"
-  xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-  xmlns:tal="http://xml.zope.org/namespaces/tal"
-  xmlns:metal="http://xml.zope.org/namespaces/metal">
-
-<tal:block
-    tal:define="items python: view.get_items()">
-
-<channel rdf:about="" tal:attributes="rdf:about request/URL">
-  <title tal:content="view/title">The title</title>
-  <link tal:content="view/link" />
-  <description tal:content="view/description" />
-  <image tal:attributes="rdf:resource string:${context/portal_url}/logo.png" />
-
-  <items>
-    <rdf:Seq>
-      <tal:block repeat="item python: items">
-        <rdf:li rdf:resource=""
-                tal:attributes="rdf:resource item/getURL" />
-      </tal:block>
-    </rdf:Seq>
-  </items>
-
-</channel>
-
-<tal:block repeat="item python: items">
-  <item rdf:about="" tal:attributes="rdf:about item/getURL">
-    <title tal:content="item/Title" />
-    <link tal:content="item/getURL" />
-    <description tal:content="item/Description" />
-    <pubDate tal:define="effective python: item.getObject().getEffectiveDate()"
-             tal:condition="effective"
-             tal:content="python: effective.strftime('%a, %e %b %Y %H:%M:%S %z')" />
-  </item>
-</tal:block>
-
-</tal:block>
-
-</rdf:RDF>
+<rss version="2.0"
+     xmlns:tal="http://xml.zope.org/namespaces/tal"
+     xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel tal:define="items view/get_items">
+        <atom:link tal:attributes="href string:${view/context/absolute_url}/${view/__name__}"
+                   rel="self"
+                   type="application/rss+xml" />
+        <title tal:content="view/title" />
+        <link tal:content="view/link" />
+        <description tal:content="view/description" />
+        <item tal:repeat='item items'>
+            <title tal:content="item/Title" />
+            <link tal:content="item/getURL" />
+            <description tal:content="item/Description" />
+            <guid tal:content="item/getURL" />
+            <pubDate tal:define="effective item/effective"
+                     tal:condition="effective"
+                     tal:content="effective/rfc822" />
+        </item>
+    </channel>
+</rss>

--- a/ftw/contentpage/tests/test_newslisting_rss.py
+++ b/ftw/contentpage/tests/test_newslisting_rss.py
@@ -36,28 +36,25 @@ class TestNewsRssListing(TestCase):
     def test_newslisting_rss_items(self):
         self.browser.open(self.newsfolder.absolute_url() + '/news_rss_listing')
 
-        rdf = '<rdf:li rdf:resource="{0}"/>'.format(
-            self.news.absolute_url())
-        self.assertIn(rdf,
+        title = '<title>{}</title>'.format(self.news.title)
+        self.assertIn(title,
                       self.browser.contents,
-                      'Did not found the rdf tag for the news')
+                      'Could not find the title of the news')
 
-        link = '<link>{0}</link>'.format(self.news.absolute_url())
+        link = '<link>{}</link>'.format(self.news.absolute_url())
         self.assertIn(link,
                       self.browser.contents,
-                      'Did not found the link tag for the news')
+                      'Could not find the link tag for the news')
 
     @browsing
     def test_newsitem_contains_pubdate(self, browser):
         browser.open(self.newsfolder, view='news_rss_listing')
         browser.parse_as_html()  # use HTML parser so that we have no XML namespaces.
 
-        effective_date = self.news.getEffectiveDate()
+        effective_date = self.news.effective()
         self.assertEqual(
-            # Difference between "%e" and "%-e":
-            # %e has a leading space on single numbers - thats why the tests
-            # failing between the 1st and the 9th every month :-)
-            # %-e Removes the leading space - only works on unix machines.
-            effective_date.strftime('%a, %-e %b %Y %H:%M:%S %z').strip(),
-            browser.css('rdf item pubDate').first.text
+            # Since w3c suggests using rfc822 for pubDate, we can simply
+            # use the already implemented method for this.
+            effective_date.rfc822(),
+            browser.css('rss item pubDate').first.text
         )


### PR DESCRIPTION
Update `newslisting_rss` view to rss version 2.0

The old template was using some features from rss v2.0 while the xml headers were set to v1.0. This caused some issues with certain rss readers.
The template now uses a valid schema for a rss feed v2.0 while still providing all the data it provided before.

<img width="883" alt="screen shot 2017-09-14 at 14 09 27" src="https://user-images.githubusercontent.com/16755391/30429054-5a442acc-9956-11e7-8caf-ba9b41ae6f52.png">
