### PR TITLE
Fix tests.

### DIFF
--- a/ftw/contentpage/tests/__init__.py
+++ b/ftw/contentpage/tests/__init__.py
@@ -1,7 +1,7 @@
 from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
+from unittest import TestCase
 import transaction
 
 

--- a/ftw/contentpage/tests/test_addressblock_creation.py
+++ b/ftw/contentpage/tests/test_addressblock_creation.py
@@ -10,7 +10,7 @@ from plone.registry import Record
 from plone.registry.interfaces import IRegistry
 from plone.testing.z2 import Browser
 from simplelayout.base.interfaces import ISimpleLayoutBlock
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import getUtility
 import transaction
 

--- a/ftw/contentpage/tests/test_anchors.py
+++ b/ftw/contentpage/tests/test_anchors.py
@@ -2,7 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
 from ftw.testbrowser import browsing
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestAnchors(TestCase):

--- a/ftw/contentpage/tests/test_archive_summary.py
+++ b/ftw/contentpage/tests/test_archive_summary.py
@@ -4,7 +4,7 @@ from ftw.builder import create
 from ftw.contentpage.portlets.base_archive_portlet import ArchiveSummary
 from ftw.contentpage.testing import FTW_CONTENTPAGE_INTEGRATION_TESTING
 from plone.app.testing import setRoles, TEST_USER_ID, TEST_USER_NAME, login
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestArchiveSummary(TestCase):

--- a/ftw/contentpage/tests/test_byline.py
+++ b/ftw/contentpage/tests/test_byline.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest as unittest
 from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
 import os
 import transaction

--- a/ftw/contentpage/tests/test_content_categorie_behavior.py
+++ b/ftw/contentpage/tests/test_content_categorie_behavior.py
@@ -9,8 +9,8 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.fti import DexterityFTI
 from Products.CMFCore.utils import getToolByName
 from simplelayout.base.views import SimpleLayoutView
-from unittest2 import skipUnless
-from unittest2 import TestCase
+from unittest import skipUnless
+from unittest import TestCase
 from zope import schema
 from zope.component import queryMultiAdapter
 from zope.interface import alsoProvides

--- a/ftw/contentpage/tests/test_contentlisting.py
+++ b/ftw/contentpage/tests/test_contentlisting.py
@@ -4,7 +4,7 @@ from plone.app.testing import TEST_USER_NAME, TEST_USER_PASSWORD
 from plone.testing.z2 import Browser
 from Products.CMFCore.utils import getToolByName
 from simplelayout.base.views import SimpleLayoutView
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.viewlet.interfaces import IViewletManager
 from zope.component import queryMultiAdapter
 import transaction

--- a/ftw/contentpage/tests/test_contentpage_creation.py
+++ b/ftw/contentpage/tests/test_contentpage_creation.py
@@ -3,7 +3,7 @@ from plone.app.testing import TEST_USER_NAME, TEST_USER_PASSWORD
 from plone.testing.z2 import Browser
 from simplelayout.base.interfaces import IAdditionalListingEnabled
 from simplelayout.base.interfaces import ISimpleLayoutCapable
-from unittest2 import TestCase
+from unittest import TestCase
 import transaction
 from zope.component import queryMultiAdapter
 from zope.publisher.browser import BrowserView

--- a/ftw/contentpage/tests/test_event_creation.py
+++ b/ftw/contentpage/tests/test_event_creation.py
@@ -3,7 +3,7 @@ from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
 from plone.app.testing import TEST_USER_NAME, TEST_USER_PASSWORD
 from plone.testing.z2 import Browser
 import transaction
-import unittest2 as unittest
+import unittest as unittest
 
 
 class TestEvent(unittest.TestCase):

--- a/ftw/contentpage/tests/test_event_date.py
+++ b/ftw/contentpage/tests/test_event_date.py
@@ -1,6 +1,6 @@
 from DateTime import DateTime
 from ftw.contentpage.browser.eventlisting import format_date
-import unittest2 as unittest
+import unittest as unittest
 
 
 class TestEvent(unittest.TestCase):

--- a/ftw/contentpage/tests/test_event_views.py
+++ b/ftw/contentpage/tests/test_event_views.py
@@ -11,7 +11,7 @@ from plone.app.testing import TEST_USER_PASSWORD
 from plone.testing.z2 import Browser
 from Products.Five.browser import BrowserView
 from pyquery import PyQuery
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import queryMultiAdapter
 from zope.viewlet.interfaces import IViewletManager
 import os

--- a/ftw/contentpage/tests/test_feedback_form.py
+++ b/ftw/contentpage/tests/test_feedback_form.py
@@ -11,7 +11,7 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.registry.interfaces import IRegistry
 from plone.testing.z2 import Browser
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import getUtility
 import transaction
 

--- a/ftw/contentpage/tests/test_finalize_schema.py
+++ b/ftw/contentpage/tests/test_finalize_schema.py
@@ -3,7 +3,7 @@ from ftw.contentpage.content.schema import finalize
 from ftw.contentpage.testing import FTW_CONTENTPAGE_INTEGRATION_TESTING
 from Products.ATContentTypes.content.schemata import ATContentTypeSchema
 from Products.CMFCore.permissions import ManagePortal
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestAddressBlockCreation(TestCase):

--- a/ftw/contentpage/tests/test_galleryblock_img_url.py
+++ b/ftw/contentpage/tests/test_galleryblock_img_url.py
@@ -4,7 +4,7 @@ from ftw.colorbox.interfaces import IColorboxSettings
 from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
 from ftw.testbrowser import browsing
 from plone.registry.interfaces import IRegistry
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import getUtility
 import transaction
 

--- a/ftw/contentpage/tests/test_geo_config_handler.py
+++ b/ftw/contentpage/tests/test_geo_config_handler.py
@@ -1,5 +1,5 @@
 from ftw.contentpage.testing import FTW_CONTENTPAGE_INTEGRATION_TESTING
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import queryAdapter
 from collective.geo.settings.interfaces import IGeoCustomFeatureStyle
 

--- a/ftw/contentpage/tests/test_ics_view.py
+++ b/ftw/contentpage/tests/test_ics_view.py
@@ -1,5 +1,5 @@
 from ftw.contentpage.testing import FTW_CONTENTPAGE_INTEGRATION_TESTING
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestICSExport(TestCase):

--- a/ftw/contentpage/tests/test_indexer.py
+++ b/ftw/contentpage/tests/test_indexer.py
@@ -1,7 +1,7 @@
 from ftw.contentpage.testing import FTW_CONTENTPAGE_INTEGRATION_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
-from unittest2 import TestCase
+from unittest import TestCase
 from plone.indexer.wrapper import IndexableObjectWrapper
 
 

--- a/ftw/contentpage/tests/test_listing_marker.py
+++ b/ftw/contentpage/tests/test_listing_marker.py
@@ -3,7 +3,7 @@ from ftw.builder import create
 from ftw.contentpage.interfaces import IAuthority
 from ftw.contentpage.testing import FTW_CONTENTPAGE_INTEGRATION_TESTING
 from Products.CMFCore.utils import getToolByName
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestMarkerInterfaceForListings(TestCase):

--- a/ftw/contentpage/tests/test_listingblock_creation.py
+++ b/ftw/contentpage/tests/test_listingblock_creation.py
@@ -1,7 +1,7 @@
 from ftw.contentpage.testing import FTW_CONTENTPAGE_INTEGRATION_TESTING
 from plone.registry.interfaces import IRegistry
 from simplelayout.base.interfaces import ISimpleLayoutBlock
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from plone.registry import Record, field

--- a/ftw/contentpage/tests/test_listingblock_table_helper.py
+++ b/ftw/contentpage/tests/test_listingblock_table_helper.py
@@ -3,7 +3,7 @@ from ftw.builder import Builder, create
 from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
 from ftw.testbrowser import browsing
 from plone.registry.interfaces import IRegistry
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import getUtility
 
 

--- a/ftw/contentpage/tests/test_listingblockviews.py
+++ b/ftw/contentpage/tests/test_listingblockviews.py
@@ -6,7 +6,7 @@ from plone.app.testing import TEST_USER_NAME, TEST_USER_PASSWORD
 from plone.app.testing import login
 from plone.app.testing import logout
 from plone.testing.z2 import Browser
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import queryMultiAdapter
 import os
 import transaction

--- a/ftw/contentpage/tests/test_news_creation.py
+++ b/ftw/contentpage/tests/test_news_creation.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest as unittest
 from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
 import transaction
 from simplelayout.base.interfaces import ISimpleLayoutCapable

--- a/ftw/contentpage/tests/test_news_effective.py
+++ b/ftw/contentpage/tests/test_news_effective.py
@@ -3,7 +3,7 @@ from ftw.builder import create
 from ftw.builder import Builder
 from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
 from pytz import timezone as tz
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestNewsEffective(TestCase):

--- a/ftw/contentpage/tests/test_news_portlets_functional.py
+++ b/ftw/contentpage/tests/test_news_portlets_functional.py
@@ -12,7 +12,7 @@ from Products.Five.browser import BrowserView
 from pyquery import PyQuery
 from zope.component import getUtility
 import transaction
-import unittest2 as unittest
+import unittest as unittest
 
 from ftw.contentpage.browser.newslisting import NewsListing
 from ftw.contentpage.portlets.news_archive_portlet import Assignment

--- a/ftw/contentpage/tests/test_news_viewlet.py
+++ b/ftw/contentpage/tests/test_news_viewlet.py
@@ -3,7 +3,7 @@ from plone.app.testing import TEST_USER_NAME, TEST_USER_PASSWORD
 from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
 from plone.testing.z2 import Browser
 import transaction
-import unittest2 as unittest
+import unittest as unittest
 
 
 class TestNewsViewlet(unittest.TestCase):

--- a/ftw/contentpage/tests/test_news_views.py
+++ b/ftw/contentpage/tests/test_news_views.py
@@ -4,7 +4,7 @@ from ftw.contentpage.testing import FTW_CONTENTPAGE_INTEGRATION_TESTING
 from plone.app.testing import TEST_USER_ID
 import datetime
 import os
-import unittest2 as unittest
+import unittest as unittest
 
 
 class TestExtendQueryByDate(unittest.TestCase):

--- a/ftw/contentpage/tests/test_newslisting.py
+++ b/ftw/contentpage/tests/test_newslisting.py
@@ -10,7 +10,7 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.testing.z2 import Browser
 from Products.CMFCore.utils import getToolByName
-from unittest2 import TestCase
+from unittest import TestCase
 import transaction
 
 

--- a/ftw/contentpage/tests/test_newslisting_rss.py
+++ b/ftw/contentpage/tests/test_newslisting_rss.py
@@ -7,7 +7,7 @@ from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.testing.z2 import Browser
-from unittest2 import TestCase
+from unittest import TestCase
 import transaction
 
 

--- a/ftw/contentpage/tests/test_newslisting_rss.py
+++ b/ftw/contentpage/tests/test_newslisting_rss.py
@@ -49,12 +49,10 @@ class TestNewsRssListing(TestCase):
     @browsing
     def test_newsitem_contains_pubdate(self, browser):
         browser.open(self.newsfolder, view='news_rss_listing')
-        browser.parse_as_html()  # use HTML parser so that we have no XML namespaces.
-
         effective_date = self.news.effective()
         self.assertEqual(
             # Since w3c suggests using rfc822 for pubDate, we can simply
             # use the already implemented method for this.
             effective_date.rfc822(),
-            browser.css('rss item pubDate').first.text
+            browser.css('pubDate').first.text
         )

--- a/ftw/contentpage/tests/test_newsportlet_listing.py
+++ b/ftw/contentpage/tests/test_newsportlet_listing.py
@@ -2,7 +2,7 @@ from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
-from unittest2 import TestCase
+from unittest import TestCase
 
 from ftw.contentpage.testing import FTW_CONTENTPAGE_FUNCTIONAL_TESTING
 

--- a/ftw/contentpage/tests/test_setuphandler.py
+++ b/ftw/contentpage/tests/test_setuphandler.py
@@ -1,5 +1,5 @@
 from ftw.contentpage.testing import FTW_CONTENTPAGE_INTEGRATION_TESTING
-from unittest2 import TestCase
+from unittest import TestCase
 from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
 from plone.registry.interfaces import IRegistry

--- a/ftw/contentpage/tests/test_subject_listing.py
+++ b/ftw/contentpage/tests/test_subject_listing.py
@@ -6,7 +6,7 @@ from ftw.contentpage.tests import FunctionalTestCase
 from ftw.contentpage.tests.pages import SubjectListingView
 from ftw.testbrowser import browsing
 from plone.registry.interfaces import IRegistry
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import getUtility
 import transaction
 

--- a/ftw/contentpage/tests/test_teaser_image.py
+++ b/ftw/contentpage/tests/test_teaser_image.py
@@ -5,7 +5,7 @@ from plone.testing.z2 import Browser
 from Products.CMFCore.utils import getToolByName
 from pyquery import PyQuery
 from StringIO import StringIO
-from unittest2 import TestCase
+from unittest import TestCase
 import transaction
 
 

--- a/ftw/contentpage/tests/test_textblock_creation.py
+++ b/ftw/contentpage/tests/test_textblock_creation.py
@@ -5,7 +5,7 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import statusmessages
 from simplelayout.base.interfaces import ISimpleLayoutBlock
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestTextBlockCreation(TestCase):

--- a/ftw/contentpage/tests/test_textblockview.py
+++ b/ftw/contentpage/tests/test_textblockview.py
@@ -3,7 +3,7 @@ from ftw.testbrowser import browsing
 from plone.app.testing import TEST_USER_NAME, TEST_USER_PASSWORD
 from plone.testing.z2 import Browser
 from simplelayout.base.utils import IBlockControl
-from unittest2 import TestCase
+from unittest import TestCase
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
 import os

--- a/ftw/contentpage/tests/test_uninstall.py
+++ b/ftw/contentpage/tests/test_uninstall.py
@@ -1,6 +1,6 @@
 from ftw.testing.genericsetup import apply_generic_setup_layer
 from ftw.testing.genericsetup import GenericSetupUninstallMixin
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 @apply_generic_setup_layer

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 version = '1.16.5.dev0'
 mainainter = 'Mathias Leimgruber'
 
-tests_require = ['ftw.testing',
+tests_require = ['ftw.testing<2a',
                  'ftw.testbrowser',
                  'ftw.builder',
                  'plone.app.testing',


### PR DESCRIPTION
- Downgrade ftw.testing so that mock tests still work.
- Use unittest instead of unittest2 (dependency was not declared).